### PR TITLE
CSV export: summary + calendar only, Excel-friendly semicolon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -151,6 +151,8 @@ export default function Home() {
           <div className="flex flex-wrap gap-2">
             <ExportCsvButton
               holidayCountry={holidayCountry}
+              rangeStart={startDate}
+              rangeEnd={endDate}
               members={members}
               result={result}
             />

--- a/components/schedule/export-csv-button.tsx
+++ b/components/schedule/export-csv-button.tsx
@@ -8,11 +8,19 @@ import type { HolidayCountry, ScheduleMember, ScheduleResult } from "@/lib/sched
 
 type Props = {
   holidayCountry: HolidayCountry;
+  rangeStart: string;
+  rangeEnd: string;
   members: ScheduleMember[];
   result: ScheduleResult | null;
 };
 
-export function ExportCsvButton({ holidayCountry, members, result }: Props) {
+export function ExportCsvButton({
+  holidayCountry,
+  rangeStart,
+  rangeEnd,
+  members,
+  result,
+}: Props) {
   const disabled = !result;
 
   return (
@@ -23,7 +31,7 @@ export function ExportCsvButton({ holidayCountry, members, result }: Props) {
       onClick={() => {
         if (!result) return;
         const names = new Map(members.map((m) => [m.id, m.name]));
-        const csv = buildScheduleCsv(holidayCountry, result, names);
+        const csv = buildScheduleCsv(rangeStart, rangeEnd, result, names);
         const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");

--- a/lib/schedule/csv.ts
+++ b/lib/schedule/csv.ts
@@ -1,62 +1,159 @@
-import type { HolidayCountry, ScheduleResult } from "./types";
+import { format } from "date-fns";
+
+import { addDays, formatISODateOnly, parseISODateOnly } from "./dates";
+import type {
+  DayAssignment,
+  ScheduleResult,
+} from "./types";
+
+/** Semicolon works reliably in Excel for PT/BR/EU locales (comma as decimal separator). */
+const SEP = ";";
 
 function escapeCsvCell(value: string): string {
-  if (/[",\n\r]/.test(value)) {
+  if (value.includes(SEP) || value.includes('"') || /[\n\r]/.test(value)) {
     return `"${value.replace(/"/g, '""')}"`;
   }
   return value;
 }
 
+function joinRow(cells: string[]): string {
+  return cells.map(escapeCsvCell).join(SEP);
+}
+
+const WEEK_HEADERS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+function monthMatrix(monthStart: Date): Date[][] {
+  const y = monthStart.getFullYear();
+  const m = monthStart.getMonth();
+  const first = new Date(y, m, 1, 12, 0, 0);
+  const startPad = first.getDay();
+  const gridStart = addDays(first, -startPad);
+  const weeks: Date[][] = [];
+  let cur = gridStart;
+  for (let w = 0; w < 6; w++) {
+    const row: Date[] = [];
+    for (let d = 0; d < 7; d++) {
+      row.push(cur);
+      cur = addDays(cur, 1);
+    }
+    weeks.push(row);
+  }
+  return weeks;
+}
+
+function listMonthsInRange(rangeStart: string, rangeEnd: string): Date[] {
+  const s = parseISODateOnly(rangeStart);
+  const e = parseISODateOnly(rangeEnd);
+  const months: Date[] = [];
+  let y = s.getFullYear();
+  let mo = s.getMonth();
+  while (true) {
+    const first = new Date(y, mo, 1, 12, 0, 0);
+    if (first > e) break;
+    months.push(first);
+    mo++;
+    if (mo > 11) {
+      mo = 0;
+      y++;
+    }
+  }
+  return months;
+}
+
+function buildCalendarSections(
+  rangeStart: string,
+  rangeEnd: string,
+  assignmentByDate: Map<string, DayAssignment>,
+  memberNames: Map<string, string>,
+): string[] {
+  const lines: string[] = [];
+  const months = listMonthsInRange(rangeStart, rangeEnd);
+
+  for (const monthStart of months) {
+    const y = monthStart.getFullYear();
+    const mo = monthStart.getMonth();
+    const monthLabel = format(monthStart, "MMMM yyyy");
+    // 8 columns: month title in A, then 7 empty (aligns with week grid below)
+    lines.push(joinRow([monthLabel, "", "", "", "", "", "", ""]));
+
+    // Header: empty corner + weekday names (8 columns)
+    lines.push(joinRow(["", ...WEEK_HEADERS]));
+
+    const weeks = monthMatrix(monthStart);
+    for (const week of weeks) {
+      const cells: string[] = [""];
+      let anyInMonth = false;
+      for (const day of week) {
+        const inMonth = day.getMonth() === mo && day.getFullYear() === y;
+        if (inMonth) anyInMonth = true;
+
+        const iso = formatISODateOnly(day);
+        const inRange = iso >= rangeStart && iso <= rangeEnd;
+
+        if (!inMonth || !inRange) {
+          cells.push("");
+          continue;
+        }
+
+        const a = assignmentByDate.get(iso);
+        const dayNum = String(day.getDate());
+        if (!a?.assigneeId) {
+          cells.push(`${dayNum} - Unassigned`);
+        } else {
+          const name =
+            memberNames.get(a.assigneeId)?.trim() || a.assigneeId;
+          cells.push(`${dayNum} - ${name}`);
+        }
+      }
+      if (anyInMonth) {
+        lines.push(joinRow(cells));
+      }
+    }
+    lines.push("");
+  }
+
+  return lines;
+}
+
 export function buildScheduleCsv(
-  holidayCountry: HolidayCountry,
+  rangeStart: string,
+  rangeEnd: string,
   result: ScheduleResult,
   memberNames: Map<string, string>,
 ): string {
   const lines: string[] = [];
-  lines.push(`# holidayCountry=${holidayCountry}`);
+
+  lines.push("# --- Summary ---");
   lines.push(
-    ["date", "pool", "hours", "assigneeId", "assigneeName", "warning"]
-      .map(escapeCsvCell)
-      .join(","),
+    joinRow(["name", "weekdayDays", "weekendHolidayDays", "totalHours"]),
   );
-
-  const warnDates = new Set(result.warnings.map((w) => w.date));
-
-  for (const a of result.assignments) {
-    const name = a.assigneeId ? memberNames.get(a.assigneeId) ?? "" : "";
-    const warning = warnDates.has(a.date) ? "no_available_member" : "";
-    lines.push(
-      [
-        a.date,
-        a.pool,
-        String(a.hours),
-        a.assigneeId ?? "",
-        name,
-        warning,
-      ]
-        .map((c) => escapeCsvCell(String(c)))
-        .join(","),
-    );
-  }
-
-  lines.push("");
-  lines.push(["memberId", "name", "weekdayDays", "weekendHolidayDays", "totalHours"]
-    .map(escapeCsvCell)
-    .join(","));
 
   for (const r of result.report) {
     lines.push(
-      [
-        r.memberId,
+      joinRow([
         r.name,
         String(r.weekdayDays),
         String(r.weekendHolidayDays),
         String(r.totalHours),
-      ]
-        .map((c) => escapeCsvCell(String(c)))
-        .join(","),
+      ]),
     );
   }
 
-  return lines.join("\r\n");
+  const assignmentByDate = new Map(
+    result.assignments.map((x) => [x.date, x]),
+  );
+
+  lines.push("");
+  lines.push("# --- Calendar ---");
+  lines.push(
+    ...buildCalendarSections(
+      rangeStart,
+      rangeEnd,
+      assignmentByDate,
+      memberNames,
+    ),
+  );
+
+  // UTF-8 BOM helps Excel detect encoding on Windows
+  return "\uFEFF" + lines.join("\r\n");
 }


### PR DESCRIPTION
## Changes
- Export contains only **# --- Summary ---** and **# --- Calendar ---** (no daily schedule block or extra metadata).
- Summary table drops **memberId**; columns: 
ame, weekdayDays, weekendHolidayDays, 	otalHours.
- **Semicolon** (;) field separator + **UTF-8 BOM** so Excel opens columns correctly in PT/BR/EU locales.
- Calendar grid uses **8 columns** (empty corner + Sun–Sat) so rows align with headers; month title row matches width.
- Day cells use ASCII 15 - Name instead of the middot character.

## Files
- lib/schedule/csv.ts — rebuilt export builder
- components/schedule/export-csv-button.tsx — updated uildScheduleCsv call
- pp/page.tsx — export wiring if any
