### PR TITLE
Month summary filter, per-month fairness, scrambled member order

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -194,12 +194,23 @@ export default function Home() {
 
         {result ? (
           <div className="grid gap-6 lg:grid-cols-1">
-            <ReportDashboard report={result.report} />
+            <ReportDashboard
+              report={result.report}
+              assignments={result.assignments}
+              members={members.map((m) => ({
+                id: m.id,
+                name: m.name.trim() || "Unnamed",
+              }))}
+              memberDisplayOrder={result.memberDisplayOrder}
+              rangeStart={startDate}
+              rangeEnd={endDate}
+            />
             <ScheduleCalendar
               rangeStart={startDate}
               rangeEnd={endDate}
               assignments={result.assignments}
               memberNames={memberNames}
+              memberDisplayOrder={result.memberDisplayOrder}
             />
           </div>
         ) : null}

--- a/components/schedule/report-dashboard.tsx
+++ b/components/schedule/report-dashboard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+
 import {
   Card,
   CardContent,
@@ -7,20 +9,115 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { PersonReport } from "@/lib/schedule/types";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  buildReportForMonth,
+  getMonthOptionsForRange,
+} from "@/lib/schedule/summary-month";
+import type { DayAssignment, PersonReport } from "@/lib/schedule/types";
+
+type MemberRef = { id: string; name: string };
 
 type Props = {
   report: PersonReport[];
+  assignments: DayAssignment[];
+  members: MemberRef[];
+  /** Scrambled cycle order from scheduler (summary + per-month rows). */
+  memberDisplayOrder: string[];
+  rangeStart: string;
+  rangeEnd: string;
 };
 
-export function ReportDashboard({ report }: Props) {
+const ALL_VALUE = "all";
+
+export function ReportDashboard({
+  report,
+  assignments,
+  members,
+  memberDisplayOrder,
+  rangeStart,
+  rangeEnd,
+}: Props) {
+  const monthOptions = useMemo(
+    () => getMonthOptionsForRange(rangeStart, rangeEnd),
+    [rangeStart, rangeEnd],
+  );
+
+  const showMonthFilter = monthOptions.length > 1;
+
+  const [monthFilter, setMonthFilter] = useState<string>(ALL_VALUE);
+
+  useEffect(() => {
+    setMonthFilter(ALL_VALUE);
+  }, [report, rangeStart, rangeEnd]);
+
+  const displayReport = useMemo(() => {
+    if (!showMonthFilter || monthFilter === ALL_VALUE) return report;
+    return buildReportForMonth(
+      assignments,
+      members,
+      monthFilter,
+      memberDisplayOrder,
+    );
+  }, [
+    showMonthFilter,
+    monthFilter,
+    report,
+    assignments,
+    members,
+    memberDisplayOrder,
+  ]);
+
+  const filterDescription = useMemo(() => {
+    if (!showMonthFilter || monthFilter === ALL_VALUE) {
+      return "Weekdays: 12 hours each. Weekends and public holidays: 24 hours each.";
+    }
+    const label =
+      monthOptions.find((o) => o.key === monthFilter)?.label ?? monthFilter;
+    return `Showing ${label} only. Weekdays: 12h, weekends/holidays: 24h.`;
+  }, [showMonthFilter, monthFilter, monthOptions]);
+
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-lg">Summary</CardTitle>
-        <CardDescription>
-          Weekdays: 12 hours each. Weekends and public holidays: 24 hours each.
-        </CardDescription>
+      <CardHeader className="space-y-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle className="text-lg">Summary</CardTitle>
+            <CardDescription>{filterDescription}</CardDescription>
+          </div>
+          {showMonthFilter ? (
+            <div className="flex w-full min-w-[12rem] flex-col gap-2 sm:w-auto sm:items-end">
+              <Label htmlFor="summary-month" className="text-muted-foreground text-xs">
+                Month
+              </Label>
+              <Select
+                value={monthFilter}
+                onValueChange={(v) => {
+                  if (v) setMonthFilter(v);
+                }}
+              >
+                <SelectTrigger id="summary-month" className="w-full sm:w-[220px]">
+                  <SelectValue placeholder="Month" />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectItem value={ALL_VALUE}>Full range</SelectItem>
+                  {monthOptions.map((o) => (
+                    <SelectItem key={o.key} value={o.key}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+        </div>
       </CardHeader>
       <CardContent className="overflow-x-auto">
         <table className="w-full min-w-[480px] text-sm">
@@ -33,7 +130,7 @@ export function ReportDashboard({ report }: Props) {
             </tr>
           </thead>
           <tbody>
-            {report.map((r) => (
+            {displayReport.map((r) => (
               <tr key={r.memberId} className="border-b border-border/60">
                 <td className="py-2 pr-4">{r.name}</td>
                 <td className="py-2 pr-4 tabular-nums">{r.weekdayDays}</td>

--- a/components/schedule/schedule-calendar.tsx
+++ b/components/schedule/schedule-calendar.tsx
@@ -21,6 +21,8 @@ type Props = {
   rangeEnd: string;
   assignments: DayAssignment[];
   memberNames: Map<string, string>;
+  /** Legend order (scrambled cycle order), not form order. */
+  memberDisplayOrder: string[];
 };
 
 function monthMatrix(monthStart: Date): Date[][] {
@@ -47,6 +49,7 @@ export function ScheduleCalendar({
   rangeEnd,
   assignments,
   memberNames,
+  memberDisplayOrder,
 }: Props) {
   const start = parseISODateOnly(rangeStart);
   const end = parseISODateOnly(rangeEnd);
@@ -166,6 +169,25 @@ export function ScheduleCalendar({
                     </span>
                   ) : null}
                 </div>
+              );
+            })}
+          </div>
+          <div className="text-muted-foreground mt-4 flex flex-wrap items-center gap-2 border-t pt-3 text-xs">
+            <span className="font-medium">People</span>
+            {memberDisplayOrder.map((id) => {
+              const name = memberNames.get(id)?.trim() || id;
+              const colors = getMemberColors(id);
+              return (
+                <span
+                  key={id}
+                  className="rounded-md border px-2 py-0.5 font-medium shadow-sm"
+                  style={{
+                    backgroundColor: colors.background,
+                    color: colors.foreground,
+                  }}
+                >
+                  {name}
+                </span>
               );
             })}
           </div>

--- a/lib/schedule/assign.ts
+++ b/lib/schedule/assign.ts
@@ -6,6 +6,7 @@ import type {
   ScheduleWarning,
   ShiftPool,
 } from "./types";
+import { memberOrderForCycle } from "./deterministic-shuffle";
 import { addDays, formatISODateOnly, isWeekend, parseISODateOnly } from "./dates";
 import type { HolidayChecker } from "./holidays";
 
@@ -28,20 +29,42 @@ function poolForDay(
   return { pool: "A", hours: 12 };
 }
 
+/** `YYYY-MM` from ISO date string */
+function monthKey(isoDate: string): string {
+  return isoDate.slice(0, 7);
+}
+
+function getM(
+  map: Map<string, number>,
+  memberId: string,
+  mk: string,
+): number {
+  return map.get(`${memberId}|${mk}`) ?? 0;
+}
+
+function bumpM(
+  map: Map<string, number>,
+  memberId: string,
+  mk: string,
+): void {
+  const key = `${memberId}|${mk}`;
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
 /**
- * Fair assignment within a day:
- * - Pool A: minimize weekday shifts, then weekend/holiday shifts (spread load),
- *   then team order.
- * - Pool B: minimize weekend/holiday shifts, then weekday shifts, then team order.
- *
- * Secondary key on the *other* pool avoids one person hoarding both buckets when
- * primary counts tie (total-hours tie-break was skewing that).
+ * Fair assignment: balance globally in the active pool first, then within the
+ * same pool for the current calendar month, then the other pool (global, then
+ * monthly), then team order. This keeps overall division even while improving
+ * per-month splits when the range spans multiple months.
  */
 function pickAssignee(
   availableIds: string[],
   pool: ShiftPool,
+  monthKeyStr: string,
   weekdayCount: Map<string, number>,
   weekendHolidayCount: Map<string, number>,
+  weekdayInMonth: Map<string, number>,
+  weekendHolidayInMonth: Map<string, number>,
   teamOrder: Map<string, number>,
 ): string {
   let best = availableIds[0]!;
@@ -49,22 +72,34 @@ function pickAssignee(
     const id = availableIds[i]!;
     const wd = weekdayCount.get(id)!;
     const wh = weekendHolidayCount.get(id)!;
+    const wdM = getM(weekdayInMonth, id, monthKeyStr);
+    const whM = getM(weekendHolidayInMonth, id, monthKeyStr);
     const bwd = weekdayCount.get(best)!;
     const bwh = weekendHolidayCount.get(best)!;
+    const bwdM = getM(weekdayInMonth, best, monthKeyStr);
+    const bwhM = getM(weekendHolidayInMonth, best, monthKeyStr);
     const ord = teamOrder.get(id)!;
     const bord = teamOrder.get(best)!;
 
     if (pool === "A") {
       if (wd < bwd) best = id;
       else if (wd > bwd) continue;
+      else if (wdM < bwdM) best = id;
+      else if (wdM > bwdM) continue;
       else if (wh < bwh) best = id;
       else if (wh > bwh) continue;
+      else if (whM < bwhM) best = id;
+      else if (whM > bwhM) continue;
       else if (ord < bord) best = id;
     } else {
       if (wh < bwh) best = id;
       else if (wh > bwh) continue;
+      else if (whM < bwhM) best = id;
+      else if (whM > bwhM) continue;
       else if (wd < bwd) best = id;
       else if (wd > bwd) continue;
+      else if (wdM < bwdM) best = id;
+      else if (wdM > bwdM) continue;
       else if (ord < bord) best = id;
     }
   }
@@ -79,12 +114,21 @@ export function assignShifts(
   const end = parseISODateOnly(input.endDate);
   const days = enumerateDaysInclusive(start, end);
 
+  const memberIds = input.members.map((m) => m.id);
+  const scrambledIds = memberOrderForCycle(
+    input.startDate,
+    input.endDate,
+    memberIds,
+  );
   const teamOrder = new Map(
-    input.members.map((m, index) => [m.id, index]),
+    scrambledIds.map((id, index) => [id, index]),
   );
 
   const weekdayCount = new Map<string, number>();
   const weekendHolidayCount = new Map<string, number>();
+  const weekdayInMonth = new Map<string, number>();
+  const weekendHolidayInMonth = new Map<string, number>();
+
   for (const m of input.members) {
     weekdayCount.set(m.id, 0);
     weekendHolidayCount.set(m.id, 0);
@@ -95,6 +139,7 @@ export function assignShifts(
 
   for (const day of days) {
     const dateStr = formatISODateOnly(day);
+    const mk = monthKey(dateStr);
     const { pool, hours } = poolForDay(day, isPublicHoliday);
 
     const available = input.members.filter(
@@ -123,18 +168,23 @@ export function assignShifts(
     const chosenId = pickAssignee(
       availableIds,
       pool,
+      mk,
       weekdayCount,
       weekendHolidayCount,
+      weekdayInMonth,
+      weekendHolidayInMonth,
       teamOrder,
     );
 
     if (pool === "A") {
       weekdayCount.set(chosenId, weekdayCount.get(chosenId)! + 1);
+      bumpM(weekdayInMonth, chosenId, mk);
     } else {
       weekendHolidayCount.set(
         chosenId,
         weekendHolidayCount.get(chosenId)! + 1,
       );
+      bumpM(weekendHolidayInMonth, chosenId, mk);
     }
 
     assignments.push({
@@ -145,7 +195,9 @@ export function assignShifts(
     });
   }
 
-  const report: PersonReport[] = input.members.map((m) => {
+  const byId = new Map(input.members.map((m) => [m.id, m]));
+  const report: PersonReport[] = scrambledIds.map((id) => {
+    const m = byId.get(id)!;
     const wd = weekdayCount.get(m.id)!;
     const wh = weekendHolidayCount.get(m.id)!;
     return {
@@ -157,5 +209,10 @@ export function assignShifts(
     };
   });
 
-  return { assignments, report, warnings };
+  return {
+    assignments,
+    report,
+    warnings,
+    memberDisplayOrder: scrambledIds,
+  };
 }

--- a/lib/schedule/deterministic-shuffle.ts
+++ b/lib/schedule/deterministic-shuffle.ts
@@ -1,0 +1,44 @@
+/**
+ * Deterministic shuffle for a shift cycle so tie-breaks do not follow form order.
+ * Same startDate + endDate + set of member ids always yields the same order.
+ */
+
+export function hashStringToSeed(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed: number) {
+  return function () {
+    let a = (seed += 0x6d2b79f5);
+    a = Math.imul(a ^ (a >>> 15), a | 1);
+    a ^= a + Math.imul(a ^ (a >>> 7), a | 61);
+    return ((a ^ (a >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function shuffleDeterministic<T>(items: readonly T[], seed: number): T[] {
+  const arr = [...items];
+  const rng = mulberry32(seed);
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/** Scrambled member ids for scheduling and UI table order (not form order). */
+export function memberOrderForCycle(
+  startDate: string,
+  endDate: string,
+  memberIds: string[],
+): string[] {
+  const sortedIds = [...memberIds].sort((a, b) => a.localeCompare(b));
+  const seedStr = `${startDate}|${endDate}|${sortedIds.join(",")}`;
+  const seed = hashStringToSeed(seedStr);
+  return shuffleDeterministic(sortedIds, seed);
+}

--- a/lib/schedule/summary-month.ts
+++ b/lib/schedule/summary-month.ts
@@ -1,0 +1,75 @@
+import { format } from "date-fns";
+
+import { parseISODateOnly } from "./dates";
+import type { DayAssignment, PersonReport } from "./types";
+
+export type MonthFilterOption = { key: string; label: string };
+
+/** YYYY-MM keys and labels for each calendar month touched by [rangeStart, rangeEnd]. */
+export function getMonthOptionsForRange(
+  rangeStart: string,
+  rangeEnd: string,
+): MonthFilterOption[] {
+  const s = parseISODateOnly(rangeStart);
+  const e = parseISODateOnly(rangeEnd);
+  const out: MonthFilterOption[] = [];
+  let y = s.getFullYear();
+  let mo = s.getMonth();
+  while (true) {
+    const first = new Date(y, mo, 1, 12, 0, 0);
+    if (first > e) break;
+    const key = `${y}-${String(mo + 1).padStart(2, "0")}`;
+    out.push({ key, label: format(first, "MMMM yyyy") });
+    mo++;
+    if (mo > 11) {
+      mo = 0;
+      y++;
+    }
+  }
+  return out;
+}
+
+type MemberRow = { id: string; name: string };
+
+/** Aggregate weekday / weekend counts and hours for one calendar month from assignments. */
+export function buildReportForMonth(
+  assignments: DayAssignment[],
+  members: MemberRow[],
+  monthKey: string,
+  /** Row order (e.g. scrambled cycle order from server); defaults to form order. */
+  memberIdsOrder?: string[],
+): PersonReport[] {
+  const weekday = new Map<string, number>();
+  const weekend = new Map<string, number>();
+  for (const m of members) {
+    weekday.set(m.id, 0);
+    weekend.set(m.id, 0);
+  }
+
+  for (const a of assignments) {
+    if (a.date.slice(0, 7) !== monthKey || !a.assigneeId) continue;
+    if (a.pool === "A") {
+      weekday.set(a.assigneeId, (weekday.get(a.assigneeId) ?? 0) + 1);
+    } else {
+      weekend.set(a.assigneeId, (weekend.get(a.assigneeId) ?? 0) + 1);
+    }
+  }
+
+  const nameById = new Map(members.map((m) => [m.id, m.name]));
+  const order =
+    memberIdsOrder && memberIdsOrder.length > 0
+      ? memberIdsOrder.filter((id) => nameById.has(id))
+      : members.map((m) => m.id);
+
+  return order.map((id) => {
+    const wd = weekday.get(id) ?? 0;
+    const wh = weekend.get(id) ?? 0;
+    return {
+      memberId: id,
+      name: nameById.get(id) ?? "",
+      weekdayDays: wd,
+      weekendHolidayDays: wh,
+      totalHours: wd * 12 + wh * 24,
+    };
+  });
+}

--- a/lib/schedule/types.ts
+++ b/lib/schedule/types.ts
@@ -44,6 +44,8 @@ export type ScheduleResult = {
   assignments: DayAssignment[];
   report: PersonReport[];
   warnings: ScheduleWarning[];
+  /** Row order for summary/export; deterministic scramble per cycle (not form order). */
+  memberDisplayOrder: string[];
 };
 
 export const scheduleMemberSchema = z.object({


### PR DESCRIPTION
## Summary
- **Summary card**: optional **Month** filter (Full range vs each calendar month) when the shift cycle spans more than one month; per-month stats derived from assignments.
- **Scheduler**: tie-break order now includes **per-month** pool counts after global pool counts, so splits are fairer **overall and by month**.
- **Display order**: tie-breaks and UI tables no longer follow form order. **memberOrderForCycle** (seed from start/end dates + sorted member ids) produces a **stable scrambled** order per cycle.
- **memberDisplayOrder** added to **ScheduleResult**; summary rows, CSV (via eport), filtered months, and calendar **People** legend use this order.

## Files
- lib/schedule/deterministic-shuffle.ts (new)
- lib/schedule/summary-month.ts (new)
- lib/schedule/assign.ts, 	ypes.ts
- components/schedule/report-dashboard.tsx, schedule-calendar.tsx
- pp/page.tsx
