### PR TITLE
docs: expand README and AGENTS for Scalify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,34 @@
+# Agent notes — Scalify
+
+Use this file with `CLAUDE.md` (which points here) and any other agent rules for this repo.
+
+## Product context
+
+- **Scalify** is a single-page scheduling tool: date range + holiday country + team (names + unavailable dates) → **Calculate shifts** → calendar, per-person report, optional CSV.
+- **Business rules** live in `lib/schedule/assign.ts` (pools A/B, fairness ordering, warnings). **Do not** duplicate that logic in the client; keep one source of truth and call `calculateSchedule` from `app/actions/schedule.ts`.
+- **Validation**: `scheduleInputSchema` and related Zod types in `lib/schedule/types.ts`. Server action already returns flattened errors; extend schemas there if inputs change.
+
+## Code map
+
+| Area | Location |
+| ---- | -------- |
+| Main UI | `app/page.tsx` |
+| Server entry for schedule | `app/actions/schedule.ts` |
+| Assignment algorithm & warnings | `lib/schedule/assign.ts` |
+| ISO dates / weekends | `lib/schedule/dates.ts` |
+| Public holidays by country | `lib/schedule/holidays.ts` |
+| CSV export helpers | `lib/schedule/csv.ts` |
+| Deterministic member display order | `lib/schedule/deterministic-shuffle.ts` |
+| Schedule UI blocks | `components/schedule/*` |
+| Shared primitives | `components/ui/*` |
+
+## Conventions
+
+- Match existing patterns: `"use client"` only where needed; server action stays `"use server"` in `app/actions/schedule.ts`.
+- Prefer extending `lib/schedule/types.ts` and reusing Zod schemas over ad-hoc validation.
+- After UI or logic changes that affect output, consider `ExportCsvButton` / `lib/schedule/csv.ts` and `ReportDashboard` / `ScheduleCalendar` together so exports and views stay aligned.
+- Avoid drive-by refactors outside the task; keep diffs focused.
+
 <!-- BEGIN:nextjs-agent-rules -->
 # This is NOT the Next.js you know
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,59 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Scalify
 
-## Getting Started
+Web app for **balancing weekday and weekend or holiday shifts** across a team. You set a date range, pick a country for public holidays, enter team members with optional unavailable dates, and get a fair assignment with a calendar view, summary report, and CSV export.
 
-First, run the development server:
+## Features
+
+- **Date range** — Schedule across any contiguous range; end date must be on or after the start date.
+- **Holidays** — Public holidays for **US**, **PT**, or **BR** (via `date-holidays`) combine with weekends to define “heavy” shift days.
+- **Shift pools** — Weekdays (non-holiday) use pool **A** (12 hours). Weekends and public holidays use pool **B** (24 hours). Assignment logic balances load within each pool and across calendar months where possible.
+- **Availability** — Per-person blocked dates; if everyone is blocked on a day, that day surfaces as a **warning** for manual follow-up.
+- **Export** — Download the schedule as CSV when you have a calculated result.
+
+## Tech stack
+
+- [Next.js](https://nextjs.org) 16 (App Router), React 19, TypeScript
+- [Tailwind CSS](https://tailwindcss.com) v4
+- Validation: [Zod](https://zod.dev)
+- UI: [Base UI](https://base-ui.com/react/overview/quick-start)–style primitives under `components/ui/`, Lucide icons, `next-themes` for light/dark
+
+## Getting started
+
+Install dependencies and run the dev server:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000). Edit the main screen in `app/page.tsx`; schedule calculation runs through the server action in `app/actions/schedule.ts`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Scripts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Command        | Description              |
+| -------------- | ------------------------ |
+| `npm run dev`  | Development server       |
+| `npm run build`| Production build         |
+| `npm run start`| Start production server  |
+| `npm run lint` | ESLint                   |
 
-## Learn More
+## Project layout (high level)
 
-To learn more about Next.js, take a look at the following resources:
+| Path | Role |
+| ---- | ---- |
+| `app/page.tsx` | Main UI: range, holidays, team, calculate, results |
+| `app/actions/schedule.ts` | Server action: validates input, runs `assignShifts` |
+| `lib/schedule/` | Types/schemas, assignment (`assign.ts`), dates, holidays, CSV, shuffle order |
+| `components/schedule/` | Calendar, report, team/date/holiday sections, CSV button |
+| `components/ui/` | Shared UI primitives |
+| `components/theme-*.tsx` | Theme provider and selector |
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Core types and the request schema live in `lib/schedule/types.ts` (`scheduleInputSchema`, `ScheduleResult`, etc.).
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Next.js in this repo
 
-## Deploy on Vercel
+This project tracks a **current** Next.js major release. APIs and conventions can differ from older tutorials. When changing routing, data fetching, or config, prefer the docs that ship with your installed version (see `node_modules/next/dist/docs/` locally or the [Next.js documentation](https://nextjs.org/docs) for your version).
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Deploy
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+A typical deployment is [Vercel](https://vercel.com) or any host that supports Node for Next.js. See the [Next.js deployment guide](https://nextjs.org/docs/app/building-your-application/deploying) for details.


### PR DESCRIPTION
## Summary
- Replace the default Next.js README with a Scalify-specific overview: features (shift pools, holidays, CSV), tech stack, scripts, and project layout.
- Extend AGENTS.md with product context, a code map, and repo conventions for agents, while preserving the existing Next.js version warning block.

## Test plan
- [x] Skim README and AGENTS on GitHub for formatting and accuracy.

Made with [Cursor](https://cursor.com)