### PR TITLE
Improve member colors and prevent consecutive shifts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,6 +43,7 @@ export default function Home() {
   const [endDate, setEndDate] = useState(defaultEnd);
   const [holidayCountry, setHolidayCountry] = useState<HolidayCountry>("US");
   const [members, setMembers] = useState<TeamMemberForm[]>(initialMembers);
+  const [colorblindMode, setColorblindMode] = useState(false);
 
   const [result, setResult] = useState<ScheduleResult | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -150,24 +151,42 @@ export default function Home() {
               <span>Ready to calculate.</span>
             )}
           </div>
-          <div className="flex flex-wrap gap-2">
-            <ExportCsvButton
-              holidayCountry={holidayCountry}
-              rangeStart={startDate}
-              rangeEnd={endDate}
-              members={members}
-              result={result}
-            />
-            <Button
+          <div className="flex flex-wrap items-center gap-3 sm:justify-end">
+            <button
               type="button"
-              disabled={!canCalculate || pending}
-              onClick={onCalculate}
+              className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50"
+              onClick={() => setColorblindMode((v) => !v)}
             >
-              {pending ? (
-                <Loader2 className="mr-2 size-4 animate-spin" />
-              ) : null}
-              Calculate shifts
-            </Button>
+              <span>Colorblind-friendly colors</span>
+              <span
+                className={
+                  colorblindMode
+                    ? "inline-flex h-4 w-7 items-center rounded-full bg-primary/80 px-0.5 text-[0.6rem] text-primary-foreground"
+                    : "inline-flex h-4 w-7 items-center justify-end rounded-full bg-muted px-0.5 text-[0.6rem]"
+                }
+              >
+                <span className="inline-block h-3 w-3 rounded-full bg-background shadow" />
+              </span>
+            </button>
+            <div className="flex flex-wrap gap-2">
+              <ExportCsvButton
+                holidayCountry={holidayCountry}
+                rangeStart={startDate}
+                rangeEnd={endDate}
+                members={members}
+                result={result}
+              />
+              <Button
+                type="button"
+                disabled={!canCalculate || pending}
+                onClick={onCalculate}
+              >
+                {pending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : null}
+                Calculate shifts
+              </Button>
+            </div>
           </div>
         </div>
 
@@ -213,6 +232,7 @@ export default function Home() {
               assignments={result.assignments}
               memberNames={memberNames}
               memberDisplayOrder={result.memberDisplayOrder}
+              colorMode={colorblindMode ? "colorblind" : "normal"}
             />
           </div>
         ) : null}

--- a/components/schedule/schedule-calendar.tsx
+++ b/components/schedule/schedule-calendar.tsx
@@ -5,12 +5,8 @@ import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  addDays,
-  formatISODateOnly,
-  parseISODateOnly,
-} from "@/lib/schedule/dates";
-import { getMemberColors } from "@/lib/schedule/colors";
+import { addDays, formatISODateOnly, parseISODateOnly } from "@/lib/schedule/dates";
+import { getMemberColors, type MemberColorMode } from "@/lib/schedule/colors";
 import type { DayAssignment } from "@/lib/schedule/types";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +19,7 @@ type Props = {
   memberNames: Map<string, string>;
   /** Legend order (scrambled cycle order), not form order. */
   memberDisplayOrder: string[];
+  colorMode: MemberColorMode;
 };
 
 function monthMatrix(monthStart: Date): Date[][] {
@@ -50,6 +47,7 @@ export function ScheduleCalendar({
   assignments,
   memberNames,
   memberDisplayOrder,
+  colorMode,
 }: Props) {
   const start = parseISODateOnly(rangeStart);
   const end = parseISODateOnly(rangeEnd);
@@ -131,7 +129,7 @@ export function ScheduleCalendar({
               const assignment = byDate.get(iso);
               const assigneeId = assignment?.assigneeId ?? null;
               const colors = assigneeId
-                ? getMemberColors(assigneeId)
+                ? getMemberColors(assigneeId, colorMode)
                 : null;
               const label = assigneeId
                 ? memberNames.get(assigneeId) ?? assigneeId
@@ -176,7 +174,7 @@ export function ScheduleCalendar({
             <span className="font-medium">People</span>
             {memberDisplayOrder.map((id) => {
               const name = memberNames.get(id)?.trim() || id;
-              const colors = getMemberColors(id);
+              const colors = getMemberColors(id, colorMode);
               return (
                 <span
                   key={id}

--- a/lib/schedule/assign.ts
+++ b/lib/schedule/assign.ts
@@ -136,6 +136,7 @@ export function assignShifts(
 
   const assignments: DayAssignment[] = [];
   const warnings: ScheduleWarning[] = [];
+  const assignmentsByDate = new Map<string, DayAssignment>();
 
   for (const day of days) {
     const dateStr = formatISODateOnly(day);
@@ -146,7 +147,23 @@ export function assignShifts(
       (m) => !m.unavailableDates.includes(dateStr),
     );
 
-    if (available.length === 0) {
+    // Enforce: no member should receive two consecutive shifts.
+    const prevDay = addDays(day, -1);
+    const prevDateStr = formatISODateOnly(prevDay);
+    const prevAssignment = assignmentsByDate.get(prevDateStr);
+    const prevAssigneeId = prevAssignment?.assigneeId ?? null;
+
+    let effectiveAvailable = available;
+    if (prevAssigneeId) {
+      const withoutPrev = available.filter((m) => m.id !== prevAssigneeId);
+      if (withoutPrev.length > 0) {
+        effectiveAvailable = withoutPrev;
+      } else {
+        effectiveAvailable = [];
+      }
+    }
+
+    if (effectiveAvailable.length === 0) {
       assignments.push({
         date: dateStr,
         pool,
@@ -157,7 +174,7 @@ export function assignShifts(
       continue;
     }
 
-    const availableIds = available
+    const availableIds = effectiveAvailable
       .map((m) => m.id)
       .sort((a, b) => {
         const oa = teamOrder.get(a)!;
@@ -188,6 +205,12 @@ export function assignShifts(
     }
 
     assignments.push({
+      date: dateStr,
+      pool,
+      assigneeId: chosenId,
+      hours,
+    });
+    assignmentsByDate.set(dateStr, {
       date: dateStr,
       pool,
       assigneeId: chosenId,

--- a/lib/schedule/colors.ts
+++ b/lib/schedule/colors.ts
@@ -3,6 +3,8 @@ export type MemberColors = {
   foreground: string;
 };
 
+export type MemberColorMode = "normal" | "colorblind";
+
 function hashString(s: string): number {
   let h = 0;
   for (let i = 0; i < s.length; i++) {
@@ -12,12 +14,36 @@ function hashString(s: string): number {
   return Math.abs(h);
 }
 
+const COLORBLIND_PALETTE: MemberColors[] = [
+  // Okabe-Ito inspired, adjusted for this UI
+  { background: "oklch(0.92 0.15 60)", foreground: "oklch(0.32 0.12 60)" }, // yellow
+  { background: "oklch(0.9 0.11 150)", foreground: "oklch(0.3 0.09 150)" }, // bluish green
+  { background: "oklch(0.9 0.12 30)", foreground: "oklch(0.3 0.1 30)" }, // orange
+  { background: "oklch(0.9 0.14 270)", foreground: "oklch(0.3 0.11 270)" }, // blue
+  { background: "oklch(0.9 0.13 330)", foreground: "oklch(0.3 0.11 330)" }, // reddish purple
+  { background: "oklch(0.9 0.12 200)", foreground: "oklch(0.3 0.09 200)" }, // sky blue
+  { background: "oklch(0.9 0.11 110)", foreground: "oklch(0.3 0.09 110)" }, // green
+  { background: "oklch(0.9 0.12 15)", foreground: "oklch(0.3 0.1 15)" }, // vermillion
+];
+
 /**
  * Distinct, readable HSL backgrounds per member; foreground is dark or light text.
  */
-export function getMemberColors(memberId: string): MemberColors {
-  const hue = hashString(memberId) % 360;
-  const background = `hsl(${hue} 55% 88%)`;
-  const foreground = `hsl(${hue} 45% 22%)`;
+export function getMemberColors(
+  memberId: string,
+  mode: MemberColorMode = "normal",
+): MemberColors {
+  const h = hashString(memberId);
+
+  if (mode === "colorblind") {
+    const idx = h % COLORBLIND_PALETTE.length;
+    return COLORBLIND_PALETTE[idx]!;
+  }
+
+  // Normal mode: spread hues around the wheel in discrete steps for clearer
+  // separation, with a light background and dark foreground.
+  const hue = (h % 12) * 30; // 12 distinct buckets around the wheel
+  const background = `hsl(${hue} 70% 88%)`;
+  const foreground = `hsl(${hue} 55% 22%)`;
   return { background, foreground };
 }


### PR DESCRIPTION
- Make default member colors more distinct and add colorblind-friendly palette
- Add inline toggle to switch calendar to colorblind-safe colors
- Enforce rule that no member is assigned on two consecutive days

Made-with: Cursor