### PR TITLE
feat(schedule): implement SCA0004 anonymous draft persistence

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
 
 import { calculateSchedule } from "@/app/actions/schedule";
@@ -15,6 +15,11 @@ import { ThemeSelector } from "@/components/theme-selector";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { addDays, formatISODateOnly } from "@/lib/schedule/dates";
+import {
+  clearScheduleDraft,
+  loadScheduleDraft,
+  saveScheduleDraft,
+} from "@/lib/schedule/draft-storage";
 import type { HolidayCountry, ScheduleResult } from "@/lib/schedule/types";
 import { scheduleInputSchema } from "@/lib/schedule/types";
 
@@ -45,6 +50,7 @@ export default function Home() {
   const [holidayCountry, setHolidayCountry] = useState<HolidayCountry>("US");
   const [members, setMembers] = useState<TeamMemberForm[]>(initialMembers);
   const [colorblindMode, setColorblindMode] = useState(false);
+  const [hasHydratedDraft, setHasHydratedDraft] = useState(false);
 
   const [result, setResult] = useState<ScheduleResult | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -84,6 +90,43 @@ export default function Home() {
       setResult(res.data);
     });
   }, [payload]);
+
+  useEffect(() => {
+    const draft = loadScheduleDraft();
+    if (!draft) {
+      setHasHydratedDraft(true);
+      return;
+    }
+    setStartDate(draft.startDate);
+    setEndDate(draft.endDate);
+    setHolidayCountry(draft.holidayCountry);
+    setMembers(draft.members);
+    setColorblindMode(draft.colorblindMode);
+    setHasHydratedDraft(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hasHydratedDraft) return;
+    saveScheduleDraft({
+      startDate,
+      endDate,
+      holidayCountry,
+      members,
+      colorblindMode,
+    });
+  }, [colorblindMode, endDate, hasHydratedDraft, holidayCountry, members, startDate]);
+
+  const resetDraft = useCallback(() => {
+    const defaults = defaultRange();
+    clearScheduleDraft();
+    setStartDate(defaults.start);
+    setEndDate(defaults.end);
+    setHolidayCountry("US");
+    setMembers(initialMembers());
+    setColorblindMode(false);
+    setResult(null);
+    setActionError(null);
+  }, []);
 
   const addMember = useCallback(() => {
     setMembers((prev) => [...prev, newMember()]);
@@ -172,6 +215,9 @@ export default function Home() {
               </span>
             </button>
             <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="ghost" onClick={resetDraft}>
+                Reset draft
+              </Button>
               <ExportCsvButton
                 holidayCountry={holidayCountry}
                 rangeStart={startDate}

--- a/lib/schedule/draft-storage.ts
+++ b/lib/schedule/draft-storage.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+import { holidayCountrySchema, scheduleMemberSchema } from "./types";
+
+const DRAFT_STORAGE_KEY = "scalify:schedule-draft:v1";
+
+const scheduleDraftSchema = z.object({
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  holidayCountry: holidayCountrySchema,
+  members: z.array(scheduleMemberSchema).min(2),
+  colorblindMode: z.boolean().default(false),
+});
+
+export type ScheduleDraft = z.infer<typeof scheduleDraftSchema>;
+
+function canUseLocalStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function loadScheduleDraft(): ScheduleDraft | null {
+  if (!canUseLocalStorage()) return null;
+  try {
+    const raw = window.localStorage.getItem(DRAFT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = scheduleDraftSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveScheduleDraft(draft: ScheduleDraft): void {
+  if (!canUseLocalStorage()) return;
+  try {
+    window.localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+  } catch {
+    // Best effort only. Ignore write failures (e.g. private mode quota restrictions).
+  }
+}
+
+export function clearScheduleDraft(): void {
+  if (!canUseLocalStorage()) return;
+  try {
+    window.localStorage.removeItem(DRAFT_STORAGE_KEY);
+  } catch {
+    // Best effort only.
+  }
+}
+

--- a/tests/draft-storage.test.ts
+++ b/tests/draft-storage.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearScheduleDraft,
+  loadScheduleDraft,
+  saveScheduleDraft,
+} from "@/lib/schedule/draft-storage";
+
+class LocalStorageMock {
+  private readonly store = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+}
+
+function installLocalStorageMock(): LocalStorageMock {
+  const localStorage = new LocalStorageMock();
+  vi.stubGlobal("window", { localStorage });
+  return localStorage;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("schedule draft local persistence", () => {
+  it("saves and restores anonymous draft state", () => {
+    installLocalStorageMock();
+
+    saveScheduleDraft({
+      startDate: "2026-04-01",
+      endDate: "2026-04-15",
+      holidayCountry: "BR",
+      members: [
+        { id: "m1", name: "Ana", unavailableDates: ["2026-04-05"] },
+        { id: "m2", name: "Bruno", unavailableDates: [] },
+      ],
+      colorblindMode: true,
+    });
+
+    expect(loadScheduleDraft()).toEqual({
+      startDate: "2026-04-01",
+      endDate: "2026-04-15",
+      holidayCountry: "BR",
+      members: [
+        { id: "m1", name: "Ana", unavailableDates: ["2026-04-05"] },
+        { id: "m2", name: "Bruno", unavailableDates: [] },
+      ],
+      colorblindMode: true,
+    });
+  });
+
+  it("restores null when persisted data is invalid", () => {
+    const localStorage = installLocalStorageMock();
+    localStorage.setItem(
+      "scalify:schedule-draft:v1",
+      JSON.stringify({ startDate: "nope" }),
+    );
+
+    expect(loadScheduleDraft()).toBeNull();
+  });
+
+  it("clears persisted draft state explicitly", () => {
+    installLocalStorageMock();
+    saveScheduleDraft({
+      startDate: "2026-04-01",
+      endDate: "2026-04-15",
+      holidayCountry: "US",
+      members: [
+        { id: "m1", name: "Ana", unavailableDates: [] },
+        { id: "m2", name: "Bruno", unavailableDates: [] },
+      ],
+      colorblindMode: false,
+    });
+
+    clearScheduleDraft();
+    expect(loadScheduleDraft()).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- persist anonymous scheduler draft inputs (`date range`, `holiday country`, `team members`, and `color mode`) in local storage while editing
- restore that draft on revisit/reload, so progress remains available even after login/signup on the same device
- add an explicit `Reset draft` action to clear persisted state and return form to defaults
- add automated tests for save, restore, invalid payload handling, and clear behaviors

## Test plan
- [x] `npm run test`