### PR TITLE
feat(team): implement SCA0005 core ownership model

### DIFF
--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -1,0 +1,131 @@
+import { TeamRole } from "@prisma/client";
+import { z } from "zod";
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/db";
+
+const createTeamInputSchema = z.object({
+  name: z.string().trim().min(1, "Team name is required."),
+});
+
+type TeamWithMemberships = {
+  id: string;
+  name: string;
+  ownerId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  memberships: Array<{
+    userId: string;
+    role: TeamRole;
+  }>;
+};
+
+export type TeamSummary = {
+  id: string;
+  name: string;
+  ownerId: string;
+  ownerRole: TeamRole;
+  memberCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export class UnauthorizedTeamAccessError extends Error {
+  constructor() {
+    super("Authentication is required for team operations.");
+    this.name = "UnauthorizedTeamAccessError";
+  }
+}
+
+export async function createTeamForCurrentUser(
+  raw: unknown,
+): Promise<TeamSummary> {
+  const userId = await requireUserId();
+  const parsed = createTeamInputSchema.parse(raw);
+
+  const team = await prisma.$transaction(async (tx) => {
+    const createdTeam = await tx.team.create({
+      data: {
+        name: parsed.name,
+        ownerId: userId,
+      },
+    });
+
+    await tx.teamMembership.create({
+      data: {
+        teamId: createdTeam.id,
+        userId,
+        role: TeamRole.OWNER,
+      },
+    });
+
+    return tx.team.findUniqueOrThrow({
+      where: { id: createdTeam.id },
+      include: {
+        memberships: {
+          select: {
+            userId: true,
+            role: true,
+          },
+        },
+      },
+    });
+  });
+
+  return toTeamSummary(team);
+}
+
+export async function listTeamsForCurrentUser(): Promise<TeamSummary[]> {
+  const userId = await requireUserId();
+
+  const teams = await prisma.team.findMany({
+    where: {
+      memberships: {
+        some: { userId },
+      },
+    },
+    include: {
+      memberships: {
+        select: {
+          userId: true,
+          role: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  return teams.map(toTeamSummary);
+}
+
+async function requireUserId(): Promise<string> {
+  const session = await auth();
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) {
+    throw new UnauthorizedTeamAccessError();
+  }
+  return userId;
+}
+
+function toTeamSummary(team: TeamWithMemberships): TeamSummary {
+  const ownerMembership = team.memberships.find(
+    (membership) =>
+      membership.userId === team.ownerId && membership.role === TeamRole.OWNER,
+  );
+
+  if (!ownerMembership) {
+    throw new Error(`Team ${team.id} is missing an OWNER membership invariant.`);
+  }
+
+  return {
+    id: team.id,
+    name: team.name,
+    ownerId: team.ownerId,
+    ownerRole: ownerMembership.role,
+    memberCount: team.memberships.length,
+    createdAt: team.createdAt,
+    updatedAt: team.updatedAt,
+  };
+}

--- a/prisma/migrations/20260424171500_team_core_schema/migration.sql
+++ b/prisma/migrations/20260424171500_team_core_schema/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "TeamRole" AS ENUM ('OWNER', 'ADMIN', 'MEMBER');
+
+-- CreateTable
+CREATE TABLE "Team" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Team_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamMembership" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "TeamRole" NOT NULL DEFAULT 'MEMBER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TeamMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamMembership_teamId_userId_key" ON "TeamMembership"("teamId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMembership" ADD CONSTRAINT "TeamMembership_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMembership" ADD CONSTRAINT "TeamMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,37 @@ model User {
   updatedAt    DateTime  @updatedAt
   accounts     Account[]
   sessions     Session[]
+  ownedTeams   Team[]          @relation("TeamOwner")
+  memberships  TeamMembership[]
+}
+
+enum TeamRole {
+  OWNER
+  ADMIN
+  MEMBER
+}
+
+model Team {
+  id          String           @id @default(cuid())
+  name        String
+  ownerId     String
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  owner       User             @relation("TeamOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  memberships TeamMembership[]
+}
+
+model TeamMembership {
+  id        String   @id @default(cuid())
+  teamId    String
+  userId    String
+  role      TeamRole @default(MEMBER)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  team      Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, userId])
 }
 
 model Account {

--- a/tests/team-service.integration.test.ts
+++ b/tests/team-service.integration.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authMock, prismaMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  prismaMock: {
+    $transaction: vi.fn(),
+    team: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+import {
+  UnauthorizedTeamAccessError,
+  createTeamForCurrentUser,
+  listTeamsForCurrentUser,
+} from "@/lib/team/service";
+
+describe("team service integration behaviors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a team with owner membership for authenticated user", async () => {
+    authMock.mockResolvedValue({
+      user: {
+        id: "user_1",
+      },
+    });
+
+    const createdAt = new Date("2026-04-24T12:00:00.000Z");
+    const updatedAt = new Date("2026-04-24T12:00:00.000Z");
+
+    const txMock = {
+      team: {
+        create: vi.fn().mockResolvedValue({
+          id: "team_1",
+          name: "Ops Team",
+          ownerId: "user_1",
+        }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "team_1",
+          name: "Ops Team",
+          ownerId: "user_1",
+          createdAt,
+          updatedAt,
+          memberships: [{ userId: "user_1", role: "OWNER" }],
+        }),
+      },
+      teamMembership: {
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(async (callback) =>
+      callback(txMock),
+    );
+
+    const result = await createTeamForCurrentUser({ name: "Ops Team" });
+
+    expect(txMock.team.create).toHaveBeenCalledWith({
+      data: {
+        name: "Ops Team",
+        ownerId: "user_1",
+      },
+    });
+    expect(txMock.teamMembership.create).toHaveBeenCalledWith({
+      data: {
+        teamId: "team_1",
+        userId: "user_1",
+        role: "OWNER",
+      },
+    });
+    expect(result.ownerRole).toBe("OWNER");
+    expect(result.memberCount).toBe(1);
+  });
+
+  it("lists only teams visible to the current user", async () => {
+    authMock.mockResolvedValue({
+      user: {
+        id: "user_1",
+      },
+    });
+
+    prismaMock.team.findMany.mockResolvedValue([
+      {
+        id: "team_1",
+        name: "Ops Team",
+        ownerId: "user_1",
+        createdAt: new Date("2026-04-24T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-24T12:00:00.000Z"),
+        memberships: [
+          { userId: "user_1", role: "OWNER" },
+          { userId: "user_2", role: "MEMBER" },
+        ],
+      },
+    ]);
+
+    const result = await listTeamsForCurrentUser();
+
+    expect(prismaMock.team.findMany).toHaveBeenCalledWith({
+      where: {
+        memberships: {
+          some: { userId: "user_1" },
+        },
+      },
+      include: {
+        memberships: {
+          select: {
+            userId: true,
+            role: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.ownerRole).toBe("OWNER");
+    expect(result[0]?.memberCount).toBe(2);
+  });
+
+  it("denies unauthenticated users for team persistence operations", async () => {
+    authMock.mockResolvedValue(null);
+
+    await expect(createTeamForCurrentUser({ name: "Hidden Team" })).rejects.toBeInstanceOf(
+      UnauthorizedTeamAccessError,
+    );
+    await expect(listTeamsForCurrentUser()).rejects.toBeInstanceOf(
+      UnauthorizedTeamAccessError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Team/TeamMembership persistence schema with owner role and migration for core team domain
- add authenticated team service operations for create/list and explicit unauthorized error handling
- add integration tests covering owner create/read behavior and unauthenticated access denial

## Test plan
- [x] npm run prisma:generate
- [x] npm run test