### PR TITLE
feat(team): save and load team availability

### DIFF
--- a/app/actions/team.ts
+++ b/app/actions/team.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { ZodError } from "zod";
+
+import {
+  TeamAccessDeniedError,
+  UnauthorizedTeamAccessError,
+  listTeamsForCurrentUser,
+  loadTeamMembersForCurrentUser,
+  saveTeamMembersForCurrentUser,
+  type TeamSummary,
+} from "@/lib/team/service";
+import type { ScheduleMember } from "@/lib/schedule/types";
+
+type TeamActionError = {
+  ok: false;
+  error: string;
+  fieldErrors?: Record<string, string[]>;
+};
+
+type TeamActionSuccess<T> = {
+  ok: true;
+  data: T;
+};
+
+export async function listTeamsAction(): Promise<
+  TeamActionSuccess<TeamSummary[]> | TeamActionError
+> {
+  try {
+    const teams = await listTeamsForCurrentUser();
+    return { ok: true, data: teams };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+export async function saveTeamMembersAction(raw: unknown): Promise<
+  TeamActionSuccess<{ teamId: string; members: ScheduleMember[] }> | TeamActionError
+> {
+  try {
+    const saved = await saveTeamMembersForCurrentUser(raw);
+    return { ok: true, data: saved };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+export async function loadTeamMembersAction(teamId: string): Promise<
+  TeamActionSuccess<{ teamId: string; members: ScheduleMember[] }> | TeamActionError
+> {
+  try {
+    const loaded = await loadTeamMembersForCurrentUser(teamId);
+    return { ok: true, data: loaded };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+function toTeamActionError(error: unknown): TeamActionError {
+  if (
+    error instanceof UnauthorizedTeamAccessError ||
+    error instanceof TeamAccessDeniedError
+  ) {
+    return { ok: false, error: error.message };
+  }
+
+  if (error instanceof ZodError) {
+    const flat = error.flatten();
+    const fieldErrors = flat.fieldErrors as Record<string, string[]>;
+    const first =
+      flat.formErrors[0] ?? Object.values(fieldErrors).flat()[0] ?? "Invalid input.";
+    return { ok: false, error: first, fieldErrors };
+  }
+
+  return { ok: false, error: "Could not complete team operation." };
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
+import { useSession } from "next-auth/react";
 
 import { calculateSchedule } from "@/app/actions/schedule";
+import {
+  listTeamsAction,
+  loadTeamMembersAction,
+  saveTeamMembersAction,
+} from "@/app/actions/team";
 import { AccountCard } from "@/components/auth/account-card";
 import { DateRangeSection } from "@/components/schedule/date-range-section";
 import { ExportCsvButton } from "@/components/schedule/export-csv-button";
@@ -14,6 +20,14 @@ import { TeamSection, type TeamMemberForm } from "@/components/schedule/team-sec
 import { ThemeSelector } from "@/components/theme-selector";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { addDays, formatISODateOnly } from "@/lib/schedule/dates";
 import {
   clearScheduleDraft,
@@ -22,6 +36,7 @@ import {
 } from "@/lib/schedule/draft-storage";
 import type { HolidayCountry, ScheduleResult } from "@/lib/schedule/types";
 import { scheduleInputSchema } from "@/lib/schedule/types";
+import type { TeamSummary } from "@/lib/team/service";
 
 function defaultRange(): { start: string; end: string } {
   const t = new Date();
@@ -44,6 +59,7 @@ const initialMembers = (): TeamMemberForm[] => [
 ];
 
 export default function Home() {
+  const { status: sessionStatus } = useSession();
   const { start: defaultStart, end: defaultEnd } = useMemo(() => defaultRange(), []);
   const [startDate, setStartDate] = useState(defaultStart);
   const [endDate, setEndDate] = useState(defaultEnd);
@@ -55,6 +71,11 @@ export default function Home() {
   const [result, setResult] = useState<ScheduleResult | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [teamActionPending, startTeamActionTransition] = useTransition();
+  const [teams, setTeams] = useState<TeamSummary[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+  const [teamError, setTeamError] = useState<string | null>(null);
+  const [teamNotice, setTeamNotice] = useState<string | null>(null);
 
   const payload = useMemo(
     () => ({
@@ -148,6 +169,83 @@ export default function Home() {
     );
   }, []);
 
+  useEffect(() => {
+    if (sessionStatus !== "authenticated") {
+      setTeams([]);
+      setSelectedTeamId(null);
+      setTeamError(null);
+      setTeamNotice(null);
+      return;
+    }
+
+    startTeamActionTransition(async () => {
+      const response = await listTeamsAction();
+      if (!response.ok) {
+        setTeams([]);
+        setSelectedTeamId(null);
+        setTeamError(response.error);
+        setTeamNotice(null);
+        return;
+      }
+      setTeams(response.data);
+      setSelectedTeamId((current) =>
+        current && response.data.some((team) => team.id === current)
+          ? current
+          : (response.data[0]?.id ?? null),
+      );
+      setTeamError(null);
+    });
+  }, [sessionStatus]);
+
+  const saveTeamDraft = useCallback(() => {
+    if (!selectedTeamId) {
+      setTeamError("Select a team before saving.");
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTeamActionTransition(async () => {
+      const response = await saveTeamMembersAction({
+        teamId: selectedTeamId,
+        members: payload.members,
+      });
+
+      if (!response.ok) {
+        setTeamError(response.error);
+        return;
+      }
+
+      setTeamNotice("Team availability saved.");
+    });
+  }, [payload.members, selectedTeamId]);
+
+  const loadTeamDraft = useCallback(() => {
+    if (!selectedTeamId) {
+      setTeamError("Select a team before loading.");
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTeamActionTransition(async () => {
+      const response = await loadTeamMembersAction(selectedTeamId);
+      if (!response.ok) {
+        setTeamError(response.error);
+        return;
+      }
+
+      setMembers(response.data.members);
+      setResult(null);
+      setActionError(null);
+      setTeamNotice(
+        response.data.members.length > 0
+          ? "Loaded saved team availability into the form."
+          : "No saved team availability found yet.",
+      );
+    });
+  }, [selectedTeamId]);
+
   return (
     <div className="bg-background min-h-full">
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10 md:px-6">
@@ -164,6 +262,79 @@ export default function Home() {
         </header>
 
         <AccountCard />
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Saved team availability</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {sessionStatus !== "authenticated" ? (
+              <p className="text-muted-foreground text-sm">
+                Log in to save and load team members with unavailable dates.
+              </p>
+            ) : (
+              <>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <Select
+                    value={selectedTeamId ?? ""}
+                    onValueChange={(value) => setSelectedTeamId(value)}
+                  >
+                    <SelectTrigger className="w-full sm:w-80">
+                      <SelectValue placeholder="Select a team" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {teams.map((team) => (
+                        <SelectItem key={team.id} value={team.id}>
+                          {team.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={loadTeamDraft}
+                      disabled={teamActionPending || !selectedTeamId}
+                    >
+                      {teamActionPending ? (
+                        <Loader2 className="mr-2 size-4 animate-spin" />
+                      ) : null}
+                      Load team
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={saveTeamDraft}
+                      disabled={teamActionPending || !selectedTeamId}
+                    >
+                      {teamActionPending ? (
+                        <Loader2 className="mr-2 size-4 animate-spin" />
+                      ) : null}
+                      Save team
+                    </Button>
+                  </div>
+                </div>
+                {teams.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    You are not in any teams yet.
+                  </p>
+                ) : null}
+              </>
+            )}
+            {teamError ? (
+              <Alert variant="destructive">
+                <AlertTitle>Team sync failed</AlertTitle>
+                <AlertDescription>{teamError}</AlertDescription>
+              </Alert>
+            ) : null}
+            {teamNotice ? (
+              <Alert>
+                <AlertTitle>Team sync</AlertTitle>
+                <AlertDescription>{teamNotice}</AlertDescription>
+              </Alert>
+            ) : null}
+          </CardContent>
+        </Card>
 
         <div className="grid gap-6 lg:grid-cols-2">
           <DateRangeSection

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,14 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
-import { useSession } from "next-auth/react";
+import Link from "next/link";
 
 import { calculateSchedule } from "@/app/actions/schedule";
-import {
-  listTeamsAction,
-  loadTeamMembersAction,
-  saveTeamMembersAction,
-} from "@/app/actions/team";
 import { AccountCard } from "@/components/auth/account-card";
 import { DateRangeSection } from "@/components/schedule/date-range-section";
 import { ExportCsvButton } from "@/components/schedule/export-csv-button";
@@ -20,14 +15,6 @@ import { TeamSection, type TeamMemberForm } from "@/components/schedule/team-sec
 import { ThemeSelector } from "@/components/theme-selector";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { addDays, formatISODateOnly } from "@/lib/schedule/dates";
 import {
   clearScheduleDraft,
@@ -36,7 +23,6 @@ import {
 } from "@/lib/schedule/draft-storage";
 import type { HolidayCountry, ScheduleResult } from "@/lib/schedule/types";
 import { scheduleInputSchema } from "@/lib/schedule/types";
-import type { TeamSummary } from "@/lib/team/service";
 
 function defaultRange(): { start: string; end: string } {
   const t = new Date();
@@ -59,7 +45,6 @@ const initialMembers = (): TeamMemberForm[] => [
 ];
 
 export default function Home() {
-  const { status: sessionStatus } = useSession();
   const { start: defaultStart, end: defaultEnd } = useMemo(() => defaultRange(), []);
   const [startDate, setStartDate] = useState(defaultStart);
   const [endDate, setEndDate] = useState(defaultEnd);
@@ -71,11 +56,6 @@ export default function Home() {
   const [result, setResult] = useState<ScheduleResult | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
-  const [teamActionPending, startTeamActionTransition] = useTransition();
-  const [teams, setTeams] = useState<TeamSummary[]>([]);
-  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
-  const [teamError, setTeamError] = useState<string | null>(null);
-  const [teamNotice, setTeamNotice] = useState<string | null>(null);
 
   const payload = useMemo(
     () => ({
@@ -169,83 +149,6 @@ export default function Home() {
     );
   }, []);
 
-  useEffect(() => {
-    if (sessionStatus !== "authenticated") {
-      setTeams([]);
-      setSelectedTeamId(null);
-      setTeamError(null);
-      setTeamNotice(null);
-      return;
-    }
-
-    startTeamActionTransition(async () => {
-      const response = await listTeamsAction();
-      if (!response.ok) {
-        setTeams([]);
-        setSelectedTeamId(null);
-        setTeamError(response.error);
-        setTeamNotice(null);
-        return;
-      }
-      setTeams(response.data);
-      setSelectedTeamId((current) =>
-        current && response.data.some((team) => team.id === current)
-          ? current
-          : (response.data[0]?.id ?? null),
-      );
-      setTeamError(null);
-    });
-  }, [sessionStatus]);
-
-  const saveTeamDraft = useCallback(() => {
-    if (!selectedTeamId) {
-      setTeamError("Select a team before saving.");
-      return;
-    }
-
-    setTeamError(null);
-    setTeamNotice(null);
-    startTeamActionTransition(async () => {
-      const response = await saveTeamMembersAction({
-        teamId: selectedTeamId,
-        members: payload.members,
-      });
-
-      if (!response.ok) {
-        setTeamError(response.error);
-        return;
-      }
-
-      setTeamNotice("Team availability saved.");
-    });
-  }, [payload.members, selectedTeamId]);
-
-  const loadTeamDraft = useCallback(() => {
-    if (!selectedTeamId) {
-      setTeamError("Select a team before loading.");
-      return;
-    }
-
-    setTeamError(null);
-    setTeamNotice(null);
-    startTeamActionTransition(async () => {
-      const response = await loadTeamMembersAction(selectedTeamId);
-      if (!response.ok) {
-        setTeamError(response.error);
-        return;
-      }
-
-      setMembers(response.data.members);
-      setResult(null);
-      setActionError(null);
-      setTeamNotice(
-        response.data.members.length > 0
-          ? "Loaded saved team availability into the form."
-          : "No saved team availability found yet.",
-      );
-    });
-  }, [selectedTeamId]);
-
   return (
     <div className="bg-background min-h-full">
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10 md:px-6">
@@ -262,79 +165,6 @@ export default function Home() {
         </header>
 
         <AccountCard />
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Saved team availability</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {sessionStatus !== "authenticated" ? (
-              <p className="text-muted-foreground text-sm">
-                Log in to save and load team members with unavailable dates.
-              </p>
-            ) : (
-              <>
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <Select
-                    value={selectedTeamId ?? ""}
-                    onValueChange={(value) => setSelectedTeamId(value)}
-                  >
-                    <SelectTrigger className="w-full sm:w-80">
-                      <SelectValue placeholder="Select a team" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {teams.map((team) => (
-                        <SelectItem key={team.id} value={team.id}>
-                          {team.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <div className="flex gap-2">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={loadTeamDraft}
-                      disabled={teamActionPending || !selectedTeamId}
-                    >
-                      {teamActionPending ? (
-                        <Loader2 className="mr-2 size-4 animate-spin" />
-                      ) : null}
-                      Load team
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={saveTeamDraft}
-                      disabled={teamActionPending || !selectedTeamId}
-                    >
-                      {teamActionPending ? (
-                        <Loader2 className="mr-2 size-4 animate-spin" />
-                      ) : null}
-                      Save team
-                    </Button>
-                  </div>
-                </div>
-                {teams.length === 0 ? (
-                  <p className="text-muted-foreground text-sm">
-                    You are not in any teams yet.
-                  </p>
-                ) : null}
-              </>
-            )}
-            {teamError ? (
-              <Alert variant="destructive">
-                <AlertTitle>Team sync failed</AlertTitle>
-                <AlertDescription>{teamError}</AlertDescription>
-              </Alert>
-            ) : null}
-            {teamNotice ? (
-              <Alert>
-                <AlertTitle>Team sync</AlertTitle>
-                <AlertDescription>{teamNotice}</AlertDescription>
-              </Alert>
-            ) : null}
-          </CardContent>
-        </Card>
 
         <div className="grid gap-6 lg:grid-cols-2">
           <DateRangeSection
@@ -356,6 +186,13 @@ export default function Home() {
           onNameChange={updateName}
           onUnavailableChange={updateUnavailable}
         />
+        <div className="text-muted-foreground text-sm">
+          Team management moved to{" "}
+          <Link href="/teams" className="text-primary underline-offset-4 hover:underline">
+            Team workspace
+          </Link>
+          . Use that page to save and load shared availability.
+        </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="text-muted-foreground text-sm">

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { Loader2 } from "lucide-react";
+import { useSession } from "next-auth/react";
+
+import {
+  listTeamsAction,
+  loadTeamMembersAction,
+  saveTeamMembersAction,
+} from "@/app/actions/team";
+import { AccountCard } from "@/components/auth/account-card";
+import { ThemeSelector } from "@/components/theme-selector";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { addDays, formatISODateOnly } from "@/lib/schedule/dates";
+import { loadScheduleDraft, saveScheduleDraft } from "@/lib/schedule/draft-storage";
+import type { TeamSummary } from "@/lib/team/service";
+
+function defaultRange(): { start: string; end: string } {
+  const t = new Date();
+  const start = new Date(t.getFullYear(), t.getMonth(), t.getDate(), 12, 0, 0);
+  const end = addDays(start, 30);
+  return {
+    start: formatISODateOnly(start),
+    end: formatISODateOnly(end),
+  };
+}
+
+function defaultMembers() {
+  return [
+    { id: "member-initial-0", name: "", unavailableDates: [] as string[] },
+    { id: "member-initial-1", name: "", unavailableDates: [] as string[] },
+  ];
+}
+
+export default function TeamsPage() {
+  const { status: sessionStatus } = useSession();
+  const [pending, startTransition] = useTransition();
+  const [teams, setTeams] = useState<TeamSummary[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+  const [teamError, setTeamError] = useState<string | null>(null);
+  const [teamNotice, setTeamNotice] = useState<string | null>(null);
+
+  const localDraft = useMemo(() => {
+    const draft = loadScheduleDraft();
+    if (draft) {
+      return draft;
+    }
+
+    const defaults = defaultRange();
+    return {
+      startDate: defaults.start,
+      endDate: defaults.end,
+      holidayCountry: "US" as const,
+      members: defaultMembers(),
+      colorblindMode: false,
+    };
+  }, []);
+
+  useEffect(() => {
+    if (sessionStatus !== "authenticated") {
+      setTeams([]);
+      setSelectedTeamId(null);
+      setTeamError(null);
+      return;
+    }
+
+    startTransition(async () => {
+      const response = await listTeamsAction();
+      if (!response.ok) {
+        setTeamError(response.error);
+        setTeams([]);
+        setSelectedTeamId(null);
+        return;
+      }
+
+      setTeams(response.data);
+      setSelectedTeamId((current) =>
+        current && response.data.some((team) => team.id === current)
+          ? current
+          : (response.data[0]?.id ?? null),
+      );
+      setTeamError(null);
+    });
+  }, [sessionStatus]);
+
+  const saveCurrentDraft = useCallback(() => {
+    if (!selectedTeamId) {
+      setTeamError("Select a team before saving.");
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTransition(async () => {
+      const response = await saveTeamMembersAction({
+        teamId: selectedTeamId,
+        members: localDraft.members.map((member) => ({
+          id: member.id,
+          name: member.name.trim(),
+          unavailableDates: member.unavailableDates,
+        })),
+      });
+
+      if (!response.ok) {
+        setTeamError(response.error);
+        return;
+      }
+
+      setTeamNotice("Saved current scheduler members and availability to this team.");
+    });
+  }, [localDraft.members, selectedTeamId]);
+
+  const loadToSchedulerDraft = useCallback(() => {
+    if (!selectedTeamId) {
+      setTeamError("Select a team before loading.");
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTransition(async () => {
+      const response = await loadTeamMembersAction(selectedTeamId);
+      if (!response.ok) {
+        setTeamError(response.error);
+        return;
+      }
+
+      saveScheduleDraft({
+        ...localDraft,
+        members:
+          response.data.members.length >= 2 ? response.data.members : defaultMembers(),
+      });
+
+      setTeamNotice(
+        response.data.members.length > 0
+          ? "Loaded team availability into your scheduler draft. Open Home to continue."
+          : "This team has no saved availability yet.",
+      );
+    });
+  }, [localDraft, selectedTeamId]);
+
+  return (
+    <div className="bg-background min-h-full">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10 md:px-6">
+        <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <h1 className="font-heading text-3xl font-semibold tracking-tight">Teams</h1>
+            <p className="text-muted-foreground text-sm md:text-base">
+              Manage shared team members and blocked dates outside the schedule page.
+            </p>
+          </div>
+          <ThemeSelector />
+        </header>
+
+        <AccountCard />
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Team list and management</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {sessionStatus !== "authenticated" ? (
+              <Alert>
+                <AlertTitle>Login required</AlertTitle>
+                <AlertDescription>
+                  Team management is only available for authenticated users.
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <Select
+                    value={selectedTeamId ?? ""}
+                    onValueChange={(value) => setSelectedTeamId(value)}
+                  >
+                    <SelectTrigger className="w-full sm:w-80">
+                      <SelectValue placeholder="Select a team" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {teams.map((team) => (
+                        <SelectItem key={team.id} value={team.id}>
+                          {team.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={loadToSchedulerDraft}
+                      disabled={pending || !selectedTeamId}
+                    >
+                      {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                      Load to draft
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={saveCurrentDraft}
+                      disabled={pending || !selectedTeamId}
+                    >
+                      {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                      Save from draft
+                    </Button>
+                  </div>
+                </div>
+                {teams.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">You are not in any teams yet.</p>
+                ) : null}
+              </>
+            )}
+            {teamError ? (
+              <Alert variant="destructive">
+                <AlertTitle>Team sync failed</AlertTitle>
+                <AlertDescription>{teamError}</AlertDescription>
+              </Alert>
+            ) : null}
+            {teamNotice ? (
+              <Alert>
+                <AlertTitle>Team sync</AlertTitle>
+                <AlertDescription>{teamNotice}</AlertDescription>
+              </Alert>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <div>
+          <Link href="/" className="text-primary text-sm underline-offset-4 hover:underline">
+            Back to scheduler
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/auth.ts
+++ b/auth.ts
@@ -50,6 +50,20 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   session: {
     strategy: "jwt",
   },
+  callbacks: {
+    jwt: async ({ token, user }) => {
+      if (user) {
+        token.id = user.id;
+      }
+      return token;
+    },
+    session: async ({ session, token }) => {
+      if (session.user && token.id) {
+        (session.user as { id?: string }).id = String(token.id);
+      }
+      return session;
+    },
+  },
 });
 
 function toAuthUser(user: User) {

--- a/components/auth/account-card.tsx
+++ b/components/auth/account-card.tsx
@@ -32,7 +32,10 @@ export function AccountCard() {
             Signed in as <span className="font-medium">{session.user.email}</span>
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="flex flex-wrap gap-2">
+          <Link href="/teams" className={buttonVariants({ variant: "secondary" })}>
+            Manage teams
+          </Link>
           <Button
             type="button"
             variant="outline"

--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -186,11 +186,22 @@ export async function loadTeamMembersForCurrentUser(
 
 async function requireUserId(): Promise<string> {
   const session = await auth();
-  const userId = (session?.user as { id?: string } | undefined)?.id;
-  if (!userId) {
-    throw new UnauthorizedTeamAccessError();
+  const user = session?.user as { id?: string; email?: string } | undefined;
+  if (user?.id) {
+    return user.id;
   }
-  return userId;
+
+  if (user?.email) {
+    const dbUser = await prisma.user.findUnique({
+      where: { email: user.email.toLowerCase() },
+      select: { id: true },
+    });
+    if (dbUser?.id) {
+      return dbUser.id;
+    }
+  }
+
+  throw new UnauthorizedTeamAccessError();
 }
 
 async function assertTeamMembership(teamId: string, userId: string): Promise<void> {

--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
+import { scheduleMemberSchema, type ScheduleMember } from "@/lib/schedule/types";
 
 const createTeamInputSchema = z.object({
   name: z.string().trim().min(1, "Team name is required."),
@@ -36,6 +37,18 @@ export class UnauthorizedTeamAccessError extends Error {
     this.name = "UnauthorizedTeamAccessError";
   }
 }
+
+export class TeamAccessDeniedError extends Error {
+  constructor() {
+    super("You do not have access to this team.");
+    this.name = "TeamAccessDeniedError";
+  }
+}
+
+const saveTeamMembersInputSchema = z.object({
+  teamId: z.string().min(1, "Team is required."),
+  members: z.array(scheduleMemberSchema).min(2, "Add at least two team members."),
+});
 
 export async function createTeamForCurrentUser(
   raw: unknown,
@@ -100,6 +113,77 @@ export async function listTeamsForCurrentUser(): Promise<TeamSummary[]> {
   return teams.map(toTeamSummary);
 }
 
+export async function saveTeamMembersForCurrentUser(
+  raw: unknown,
+): Promise<{ teamId: string; members: ScheduleMember[] }> {
+  const userId = await requireUserId();
+  const parsed = saveTeamMembersInputSchema.parse(raw);
+
+  await assertTeamMembership(parsed.teamId, userId);
+
+  const members = parsed.members.map((member) => ({
+    id: member.id,
+    name: member.name.trim(),
+    unavailableDates: [...member.unavailableDates].sort(),
+  }));
+
+  const duplicateNames = new Set<string>();
+  const seenNames = new Set<string>();
+  for (const member of members) {
+    const normalized = member.name.toLowerCase();
+    if (seenNames.has(normalized)) {
+      duplicateNames.add(member.name);
+    }
+    seenNames.add(normalized);
+  }
+
+  if (duplicateNames.size > 0) {
+    throw new z.ZodError([
+      {
+        code: "custom",
+        path: ["members"],
+        message: "Member names must be unique for the selected team.",
+      },
+    ]);
+  }
+
+  await prisma.teamRoster.upsert({
+    where: { teamId: parsed.teamId },
+    create: {
+      teamId: parsed.teamId,
+      members,
+    },
+    update: {
+      members,
+    },
+  });
+
+  return {
+    teamId: parsed.teamId,
+    members,
+  };
+}
+
+export async function loadTeamMembersForCurrentUser(
+  teamId: string,
+): Promise<{ teamId: string; members: ScheduleMember[] }> {
+  const userId = await requireUserId();
+  const parsedTeamId = z.string().min(1, "Team is required.").parse(teamId);
+
+  await assertTeamMembership(parsedTeamId, userId);
+
+  const roster = await prisma.teamRoster.findUnique({
+    where: { teamId: parsedTeamId },
+    select: { members: true },
+  });
+
+  const members = z.array(scheduleMemberSchema).parse(roster?.members ?? []);
+  return {
+    teamId: parsedTeamId,
+    members,
+  };
+}
+
 async function requireUserId(): Promise<string> {
   const session = await auth();
   const userId = (session?.user as { id?: string } | undefined)?.id;
@@ -107,6 +191,22 @@ async function requireUserId(): Promise<string> {
     throw new UnauthorizedTeamAccessError();
   }
   return userId;
+}
+
+async function assertTeamMembership(teamId: string, userId: string): Promise<void> {
+  const membership = await prisma.teamMembership.findUnique({
+    where: {
+      teamId_userId: {
+        teamId,
+        userId,
+      },
+    },
+    select: { id: true },
+  });
+
+  if (!membership) {
+    throw new TeamAccessDeniedError();
+  }
 }
 
 function toTeamSummary(team: TeamWithMemberships): TeamSummary {

--- a/prisma/migrations/20260424183000_team_roster_persistence/migration.sql
+++ b/prisma/migrations/20260424183000_team_roster_persistence/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "TeamRoster" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "members" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TeamRoster_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamRoster_teamId_key" ON "TeamRoster"("teamId");
+
+-- AddForeignKey
+ALTER TABLE "TeamRoster" ADD CONSTRAINT "TeamRoster_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Team {
   updatedAt   DateTime         @updatedAt
   owner       User             @relation("TeamOwner", fields: [ownerId], references: [id], onDelete: Cascade)
   memberships TeamMembership[]
+  roster      TeamRoster?
 }
 
 model TeamMembership {
@@ -49,6 +50,15 @@ model TeamMembership {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([teamId, userId])
+}
+
+model TeamRoster {
+  id        String   @id @default(cuid())
+  teamId    String   @unique
+  members   Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  team      Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
 }
 
 model Account {

--- a/tests/team-service.integration.test.ts
+++ b/tests/team-service.integration.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { calculateSchedule } from "@/app/actions/schedule";
 
 const { authMock, prismaMock } = vi.hoisted(() => ({
   authMock: vi.fn(),
@@ -6,6 +7,13 @@ const { authMock, prismaMock } = vi.hoisted(() => ({
     $transaction: vi.fn(),
     team: {
       findMany: vi.fn(),
+    },
+    teamMembership: {
+      findUnique: vi.fn(),
+    },
+    teamRoster: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
     },
   },
 }));
@@ -19,9 +27,12 @@ vi.mock("@/lib/db", () => ({
 }));
 
 import {
+  TeamAccessDeniedError,
   UnauthorizedTeamAccessError,
   createTeamForCurrentUser,
+  loadTeamMembersForCurrentUser,
   listTeamsForCurrentUser,
+  saveTeamMembersForCurrentUser,
 } from "@/lib/team/service";
 
 describe("team service integration behaviors", () => {
@@ -138,5 +149,130 @@ describe("team service integration behaviors", () => {
     await expect(listTeamsForCurrentUser()).rejects.toBeInstanceOf(
       UnauthorizedTeamAccessError,
     );
+  });
+
+  it("saves team members and availability for accessible team", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ id: "membership_1" });
+    prismaMock.teamRoster.upsert.mockResolvedValue({});
+
+    const result = await saveTeamMembersForCurrentUser({
+      teamId: "team_1",
+      members: [
+        {
+          id: "member_a",
+          name: "Alice",
+          unavailableDates: ["2026-04-29"],
+        },
+        {
+          id: "member_b",
+          name: "Bob",
+          unavailableDates: [],
+        },
+      ],
+    });
+
+    expect(prismaMock.teamMembership.findUnique).toHaveBeenCalledWith({
+      where: {
+        teamId_userId: {
+          teamId: "team_1",
+          userId: "user_1",
+        },
+      },
+      select: { id: true },
+    });
+    expect(prismaMock.teamRoster.upsert).toHaveBeenCalledWith({
+      where: { teamId: "team_1" },
+      create: {
+        teamId: "team_1",
+        members: result.members,
+      },
+      update: {
+        members: result.members,
+      },
+    });
+    expect(result.members).toHaveLength(2);
+  });
+
+  it("returns empty members when a team has no saved roster yet", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ id: "membership_1" });
+    prismaMock.teamRoster.findUnique.mockResolvedValue(null);
+
+    const result = await loadTeamMembersForCurrentUser("team_1");
+    expect(result.members).toEqual([]);
+  });
+
+  it("denies roster access for non-members", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+    prismaMock.teamMembership.findUnique.mockResolvedValue(null);
+
+    await expect(
+      saveTeamMembersForCurrentUser({
+        teamId: "team_2",
+        members: [
+          { id: "m1", name: "A", unavailableDates: [] },
+          { id: "m2", name: "B", unavailableDates: [] },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(TeamAccessDeniedError);
+  });
+
+  it("supports save then load then schedule generation with loaded roster", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ id: "membership_1" });
+    prismaMock.teamRoster.upsert.mockResolvedValue({});
+    prismaMock.teamRoster.findUnique.mockResolvedValue({
+      members: [
+        {
+          id: "member_a",
+          name: "Alice",
+          unavailableDates: ["2026-05-01"],
+        },
+        {
+          id: "member_b",
+          name: "Bob",
+          unavailableDates: [],
+        },
+      ],
+    });
+
+    await saveTeamMembersForCurrentUser({
+      teamId: "team_1",
+      members: [
+        {
+          id: "member_a",
+          name: "Alice",
+          unavailableDates: ["2026-05-01"],
+        },
+        {
+          id: "member_b",
+          name: "Bob",
+          unavailableDates: [],
+        },
+      ],
+    });
+
+    const loaded = await loadTeamMembersForCurrentUser("team_1");
+    const schedule = await calculateSchedule({
+      startDate: "2026-05-01",
+      endDate: "2026-05-07",
+      holidayCountry: "US",
+      members: loaded.members,
+    });
+
+    expect(schedule.ok).toBe(true);
+    if (schedule.ok) {
+      expect(schedule.data.assignments.length).toBeGreaterThan(0);
+      expect(schedule.data.report).toHaveLength(2);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- persist per-team members and unavailable dates with `TeamRoster` storage and service/action endpoints
- add authenticated save/load controls on home so saved team data can repopulate the scheduler form
- extend integration coverage with save/load behavior and a save -> load -> calculate regression path

## Test plan
- [x] npm run prisma:generate
- [x] npm run test

Closes #14