### PR TITLE
feat(team): enforce role-based domain guards

### DIFF
--- a/app/actions/team.ts
+++ b/app/actions/team.ts
@@ -4,6 +4,7 @@ import { ZodError } from "zod";
 
 import {
   TeamAccessDeniedError,
+  TeamPermissionDeniedError,
   UnauthorizedTeamAccessError,
   listTeamsForCurrentUser,
   loadTeamMembersForCurrentUser,
@@ -15,6 +16,7 @@ import type { ScheduleMember } from "@/lib/schedule/types";
 type TeamActionError = {
   ok: false;
   error: string;
+  code?: "unauthorized" | "not_member" | "forbidden";
   fieldErrors?: Record<string, string[]>;
 };
 
@@ -58,10 +60,17 @@ export async function loadTeamMembersAction(teamId: string): Promise<
 
 function toTeamActionError(error: unknown): TeamActionError {
   if (
-    error instanceof UnauthorizedTeamAccessError ||
-    error instanceof TeamAccessDeniedError
+    error instanceof UnauthorizedTeamAccessError
   ) {
-    return { ok: false, error: error.message };
+    return { ok: false, error: error.message, code: "unauthorized" };
+  }
+
+  if (error instanceof TeamAccessDeniedError) {
+    return { ok: false, error: error.message, code: "not_member" };
+  }
+
+  if (error instanceof TeamPermissionDeniedError) {
+    return { ok: false, error: error.message, code: "forbidden" };
   }
 
   if (error instanceof ZodError) {

--- a/lib/team/rbac.ts
+++ b/lib/team/rbac.ts
@@ -1,0 +1,22 @@
+import { TeamRole } from "@prisma/client";
+
+export type TeamPermission = "team:roster:read" | "team:roster:write";
+
+const rolePermissionMatrix: Record<TeamRole, Record<TeamPermission, boolean>> = {
+  [TeamRole.OWNER]: {
+    "team:roster:read": true,
+    "team:roster:write": true,
+  },
+  [TeamRole.ADMIN]: {
+    "team:roster:read": true,
+    "team:roster:write": true,
+  },
+  [TeamRole.MEMBER]: {
+    "team:roster:read": true,
+    "team:roster:write": false,
+  },
+};
+
+export function canTeamRole(role: TeamRole, permission: TeamPermission): boolean {
+  return rolePermissionMatrix[role][permission];
+}

--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import { scheduleMemberSchema, type ScheduleMember } from "@/lib/schedule/types";
+import { canTeamRole, type TeamPermission } from "@/lib/team/rbac";
 
 const createTeamInputSchema = z.object({
   name: z.string().trim().min(1, "Team name is required."),
@@ -42,6 +43,13 @@ export class TeamAccessDeniedError extends Error {
   constructor() {
     super("You do not have access to this team.");
     this.name = "TeamAccessDeniedError";
+  }
+}
+
+export class TeamPermissionDeniedError extends Error {
+  constructor() {
+    super("You do not have permission for this team action.");
+    this.name = "TeamPermissionDeniedError";
   }
 }
 
@@ -119,7 +127,7 @@ export async function saveTeamMembersForCurrentUser(
   const userId = await requireUserId();
   const parsed = saveTeamMembersInputSchema.parse(raw);
 
-  await assertTeamMembership(parsed.teamId, userId);
+  await assertTeamPermission(parsed.teamId, userId, "team:roster:write");
 
   const members = parsed.members.map((member) => ({
     id: member.id,
@@ -170,7 +178,7 @@ export async function loadTeamMembersForCurrentUser(
   const userId = await requireUserId();
   const parsedTeamId = z.string().min(1, "Team is required.").parse(teamId);
 
-  await assertTeamMembership(parsedTeamId, userId);
+  await assertTeamPermission(parsedTeamId, userId, "team:roster:read");
 
   const roster = await prisma.teamRoster.findUnique({
     where: { teamId: parsedTeamId },
@@ -204,7 +212,11 @@ async function requireUserId(): Promise<string> {
   throw new UnauthorizedTeamAccessError();
 }
 
-async function assertTeamMembership(teamId: string, userId: string): Promise<void> {
+async function assertTeamPermission(
+  teamId: string,
+  userId: string,
+  permission: TeamPermission,
+): Promise<void> {
   const membership = await prisma.teamMembership.findUnique({
     where: {
       teamId_userId: {
@@ -212,11 +224,15 @@ async function assertTeamMembership(teamId: string, userId: string): Promise<voi
         userId,
       },
     },
-    select: { id: true },
+    select: { role: true },
   });
 
   if (!membership) {
     throw new TeamAccessDeniedError();
+  }
+
+  if (!canTeamRole(membership.role, permission)) {
+    throw new TeamPermissionDeniedError();
   }
 }
 

--- a/tests/team-rbac.test.ts
+++ b/tests/team-rbac.test.ts
@@ -1,0 +1,25 @@
+import { TeamRole } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { canTeamRole, type TeamPermission } from "@/lib/team/rbac";
+
+describe("team role permission matrix", () => {
+  const matrix: Array<{
+    role: TeamRole;
+    permission: TeamPermission;
+    allowed: boolean;
+  }> = [
+    { role: TeamRole.OWNER, permission: "team:roster:read", allowed: true },
+    { role: TeamRole.OWNER, permission: "team:roster:write", allowed: true },
+    { role: TeamRole.ADMIN, permission: "team:roster:read", allowed: true },
+    { role: TeamRole.ADMIN, permission: "team:roster:write", allowed: true },
+    { role: TeamRole.MEMBER, permission: "team:roster:read", allowed: true },
+    { role: TeamRole.MEMBER, permission: "team:roster:write", allowed: false },
+  ];
+
+  for (const entry of matrix) {
+    it(`${entry.role} ${entry.allowed ? "can" : "cannot"} ${entry.permission}`, () => {
+      expect(canTeamRole(entry.role, entry.permission)).toBe(entry.allowed);
+    });
+  }
+});

--- a/tests/team-service.integration.test.ts
+++ b/tests/team-service.integration.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/db", () => ({
 
 import {
   TeamAccessDeniedError,
+  TeamPermissionDeniedError,
   UnauthorizedTeamAccessError,
   createTeamForCurrentUser,
   loadTeamMembersForCurrentUser,
@@ -155,7 +156,7 @@ describe("team service integration behaviors", () => {
     authMock.mockResolvedValue({
       user: { id: "user_1" },
     });
-    prismaMock.teamMembership.findUnique.mockResolvedValue({ id: "membership_1" });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "OWNER" });
     prismaMock.teamRoster.upsert.mockResolvedValue({});
 
     const result = await saveTeamMembersForCurrentUser({
@@ -181,7 +182,7 @@ describe("team service integration behaviors", () => {
           userId: "user_1",
         },
       },
-      select: { id: true },
+      select: { role: true },
     });
     expect(prismaMock.teamRoster.upsert).toHaveBeenCalledWith({
       where: { teamId: "team_1" },
@@ -200,7 +201,7 @@ describe("team service integration behaviors", () => {
     authMock.mockResolvedValue({
       user: { id: "user_1" },
     });
-    prismaMock.teamMembership.findUnique.mockResolvedValue({ id: "membership_1" });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "OWNER" });
     prismaMock.teamRoster.findUnique.mockResolvedValue(null);
 
     const result = await loadTeamMembersForCurrentUser("team_1");
@@ -224,11 +225,44 @@ describe("team service integration behaviors", () => {
     ).rejects.toBeInstanceOf(TeamAccessDeniedError);
   });
 
+  it("denies roster writes for members without write permission", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "MEMBER" });
+
+    await expect(
+      saveTeamMembersForCurrentUser({
+        teamId: "team_1",
+        members: [
+          { id: "m1", name: "A", unavailableDates: [] },
+          { id: "m2", name: "B", unavailableDates: [] },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(TeamPermissionDeniedError);
+  });
+
+  it("allows roster reads for member role", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "MEMBER" });
+    prismaMock.teamRoster.findUnique.mockResolvedValue({
+      members: [
+        { id: "m1", name: "Alice", unavailableDates: [] },
+        { id: "m2", name: "Bob", unavailableDates: [] },
+      ],
+    });
+
+    const loaded = await loadTeamMembersForCurrentUser("team_1");
+    expect(loaded.members).toHaveLength(2);
+  });
+
   it("supports save then load then schedule generation with loaded roster", async () => {
     authMock.mockResolvedValue({
       user: { id: "user_1" },
     });
-    prismaMock.teamMembership.findUnique.mockResolvedValue({ id: "membership_1" });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "OWNER" });
     prismaMock.teamRoster.upsert.mockResolvedValue({});
     prismaMock.teamRoster.findUnique.mockResolvedValue({
       members: [


### PR DESCRIPTION
## Summary
- define a reusable team RBAC permission matrix for Owner/Admin/Member roles
- enforce permission guards in roster save/load service methods across server boundaries
- standardize team action unauthorized/not-member/forbidden responses and add role matrix tests

## Test plan
- [x] npm run test

Closes #15