### PR TITLE
feat(team): role-aware team management UI

### DIFF
--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select";
 import { addDays, formatISODateOnly } from "@/lib/schedule/dates";
 import { loadScheduleDraft, saveScheduleDraft } from "@/lib/schedule/draft-storage";
+import { canSaveTeamRoster, teamRosterPermissionHint } from "@/lib/team/roster-ui";
 import type { TeamSummary } from "@/lib/team/service";
 
 function defaultRange(): { start: string; end: string } {
@@ -94,9 +95,21 @@ export default function TeamsPage() {
     });
   }, [sessionStatus]);
 
+  const selectedTeam = useMemo(
+    () => teams.find((team) => team.id === selectedTeamId) ?? null,
+    [selectedTeamId, teams],
+  );
+
+  const canSaveFromDraft = canSaveTeamRoster(selectedTeam);
+  const rosterPermissionHint = teamRosterPermissionHint(selectedTeam);
+
   const saveCurrentDraft = useCallback(() => {
     if (!selectedTeamId) {
       setTeamError("Select a team before saving.");
+      return;
+    }
+    if (!canSaveFromDraft) {
+      setTeamError("Your role can view roster data but cannot save changes for this team.");
       return;
     }
 
@@ -113,13 +126,17 @@ export default function TeamsPage() {
       });
 
       if (!response.ok) {
-        setTeamError(response.error);
+        setTeamError(
+          response.code === "forbidden"
+            ? "Your role can view roster data but cannot save changes for this team."
+            : response.error,
+        );
         return;
       }
 
       setTeamNotice("Saved current scheduler members and availability to this team.");
     });
-  }, [localDraft.members, selectedTeamId]);
+  }, [canSaveFromDraft, localDraft.members, selectedTeamId]);
 
   const loadToSchedulerDraft = useCallback(() => {
     if (!selectedTeamId) {
@@ -183,6 +200,7 @@ export default function TeamsPage() {
                   <Select
                     value={selectedTeamId ?? ""}
                     onValueChange={(value) => setSelectedTeamId(value)}
+                    disabled={teams.length === 0}
                   >
                     <SelectTrigger className="w-full sm:w-80">
                       <SelectValue placeholder="Select a team" />
@@ -208,13 +226,16 @@ export default function TeamsPage() {
                     <Button
                       type="button"
                       onClick={saveCurrentDraft}
-                      disabled={pending || !selectedTeamId}
+                      disabled={pending || !selectedTeamId || !canSaveFromDraft}
                     >
                       {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
                       Save from draft
                     </Button>
                   </div>
                 </div>
+                {rosterPermissionHint ? (
+                  <p className="text-muted-foreground text-sm">{rosterPermissionHint}</p>
+                ) : null}
                 {teams.length === 0 ? (
                   <p className="text-muted-foreground text-sm">You are not in any teams yet.</p>
                 ) : null}

--- a/lib/team/roster-ui.ts
+++ b/lib/team/roster-ui.ts
@@ -1,0 +1,15 @@
+import type { TeamSummary } from "@/lib/team/service";
+
+export function canSaveTeamRoster(team: TeamSummary | null): boolean {
+  return Boolean(team?.canManageRoster);
+}
+
+export function teamRosterPermissionHint(team: TeamSummary | null): string | null {
+  if (!team) {
+    return null;
+  }
+
+  return team.canManageRoster
+    ? `Your role: ${team.currentUserRole}. You can load and save team roster drafts.`
+    : `Your role: ${team.currentUserRole}. You can load team drafts but cannot save roster changes.`;
+}

--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -27,6 +27,8 @@ export type TeamSummary = {
   name: string;
   ownerId: string;
   ownerRole: TeamRole;
+  currentUserRole: TeamRole;
+  canManageRoster: boolean;
   memberCount: number;
   createdAt: Date;
   updatedAt: Date;
@@ -93,7 +95,7 @@ export async function createTeamForCurrentUser(
     });
   });
 
-  return toTeamSummary(team);
+  return toTeamSummary(team, userId);
 }
 
 export async function listTeamsForCurrentUser(): Promise<TeamSummary[]> {
@@ -118,7 +120,7 @@ export async function listTeamsForCurrentUser(): Promise<TeamSummary[]> {
     },
   });
 
-  return teams.map(toTeamSummary);
+  return teams.map((team) => toTeamSummary(team, userId));
 }
 
 export async function saveTeamMembersForCurrentUser(
@@ -236,13 +238,16 @@ async function assertTeamPermission(
   }
 }
 
-function toTeamSummary(team: TeamWithMemberships): TeamSummary {
+function toTeamSummary(team: TeamWithMemberships, currentUserId: string): TeamSummary {
   const ownerMembership = team.memberships.find(
     (membership) =>
       membership.userId === team.ownerId && membership.role === TeamRole.OWNER,
   );
+  const currentUserMembership = team.memberships.find(
+    (membership) => membership.userId === currentUserId,
+  );
 
-  if (!ownerMembership) {
+  if (!ownerMembership || !currentUserMembership) {
     throw new Error(`Team ${team.id} is missing an OWNER membership invariant.`);
   }
 
@@ -251,6 +256,8 @@ function toTeamSummary(team: TeamWithMemberships): TeamSummary {
     name: team.name,
     ownerId: team.ownerId,
     ownerRole: ownerMembership.role,
+    currentUserRole: currentUserMembership.role,
+    canManageRoster: canTeamRole(currentUserMembership.role, "team:roster:write"),
     memberCount: team.memberships.length,
     createdAt: team.createdAt,
     updatedAt: team.updatedAt,

--- a/tests/team-roster-ui.test.ts
+++ b/tests/team-roster-ui.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { canSaveTeamRoster, teamRosterPermissionHint } from "@/lib/team/roster-ui";
+import type { TeamSummary } from "@/lib/team/service";
+
+function makeTeam(overrides: Partial<TeamSummary> = {}): TeamSummary {
+  return {
+    id: "team_1",
+    name: "Ops Team",
+    ownerId: "user_1",
+    ownerRole: "OWNER",
+    currentUserRole: "OWNER",
+    canManageRoster: true,
+    memberCount: 2,
+    createdAt: new Date("2026-04-24T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-24T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("team roster UI permission helpers", () => {
+  it("allows save controls for writable roles", () => {
+    expect(canSaveTeamRoster(makeTeam())).toBe(true);
+  });
+
+  it("returns read-only behavior for member role", () => {
+    const team = makeTeam({ currentUserRole: "MEMBER", canManageRoster: false });
+    expect(canSaveTeamRoster(team)).toBe(false);
+    expect(teamRosterPermissionHint(team)).toContain("cannot save roster changes");
+  });
+
+  it("returns no hint without selected team", () => {
+    expect(teamRosterPermissionHint(null)).toBeNull();
+  });
+});

--- a/tests/team-service.integration.test.ts
+++ b/tests/team-service.integration.test.ts
@@ -92,6 +92,8 @@ describe("team service integration behaviors", () => {
       },
     });
     expect(result.ownerRole).toBe("OWNER");
+    expect(result.currentUserRole).toBe("OWNER");
+    expect(result.canManageRoster).toBe(true);
     expect(result.memberCount).toBe(1);
   });
 
@@ -138,7 +140,36 @@ describe("team service integration behaviors", () => {
     });
     expect(result).toHaveLength(1);
     expect(result[0]?.ownerRole).toBe("OWNER");
+    expect(result[0]?.currentUserRole).toBe("OWNER");
+    expect(result[0]?.canManageRoster).toBe(true);
     expect(result[0]?.memberCount).toBe(2);
+  });
+
+  it("lists member teams as read-only for roster management", async () => {
+    authMock.mockResolvedValue({
+      user: {
+        id: "user_2",
+      },
+    });
+
+    prismaMock.team.findMany.mockResolvedValue([
+      {
+        id: "team_1",
+        name: "Ops Team",
+        ownerId: "user_1",
+        createdAt: new Date("2026-04-24T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-24T12:00:00.000Z"),
+        memberships: [
+          { userId: "user_1", role: "OWNER" },
+          { userId: "user_2", role: "MEMBER" },
+        ],
+      },
+    ]);
+
+    const result = await listTeamsForCurrentUser();
+
+    expect(result[0]?.currentUserRole).toBe("MEMBER");
+    expect(result[0]?.canManageRoster).toBe(false);
   });
 
   it("denies unauthenticated users for team persistence operations", async () => {


### PR DESCRIPTION
## Summary
- add role-aware team metadata (`currentUserRole`, `canManageRoster`) to team summaries
- update `/teams` UI to show role permissions and disable save controls for read-only members
- add tests for team summary role flags and UI permission helper behavior

## Test plan
- [x] Run `npm run test`

Closes #16