### PR TITLE
feat(team): add team member by existing email

### DIFF
--- a/app/actions/team.ts
+++ b/app/actions/team.ts
@@ -3,9 +3,12 @@
 import { ZodError } from "zod";
 
 import {
+  TeamMemberAlreadyExistsError,
+  TeamMemberTargetNotFoundError,
   TeamAccessDeniedError,
   TeamPermissionDeniedError,
   UnauthorizedTeamAccessError,
+  addTeamMemberByEmailForCurrentUser,
   listTeamsForCurrentUser,
   loadTeamMembersForCurrentUser,
   saveTeamMembersForCurrentUser,
@@ -16,7 +19,12 @@ import type { ScheduleMember } from "@/lib/schedule/types";
 type TeamActionError = {
   ok: false;
   error: string;
-  code?: "unauthorized" | "not_member" | "forbidden";
+  code?:
+    | "unauthorized"
+    | "not_member"
+    | "forbidden"
+    | "target_user_not_found"
+    | "already_member";
   fieldErrors?: Record<string, string[]>;
 };
 
@@ -58,6 +66,17 @@ export async function loadTeamMembersAction(teamId: string): Promise<
   }
 }
 
+export async function addTeamMemberByEmailAction(raw: unknown): Promise<
+  TeamActionSuccess<{ teamId: string; userId: string; email: string; role: string }> | TeamActionError
+> {
+  try {
+    const created = await addTeamMemberByEmailForCurrentUser(raw);
+    return { ok: true, data: created };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
 function toTeamActionError(error: unknown): TeamActionError {
   if (
     error instanceof UnauthorizedTeamAccessError
@@ -71,6 +90,14 @@ function toTeamActionError(error: unknown): TeamActionError {
 
   if (error instanceof TeamPermissionDeniedError) {
     return { ok: false, error: error.message, code: "forbidden" };
+  }
+
+  if (error instanceof TeamMemberTargetNotFoundError) {
+    return { ok: false, error: error.message, code: "target_user_not_found" };
+  }
+
+  if (error instanceof TeamMemberAlreadyExistsError) {
+    return { ok: false, error: error.message, code: "already_member" };
   }
 
   if (error instanceof ZodError) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,6 +57,20 @@ export default function Home() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
+  const hydrateFromDraft = useCallback(() => {
+    const draft = loadScheduleDraft();
+    if (!draft) {
+      setHasHydratedDraft(true);
+      return;
+    }
+    setStartDate(draft.startDate);
+    setEndDate(draft.endDate);
+    setHolidayCountry(draft.holidayCountry);
+    setMembers(draft.members);
+    setColorblindMode(draft.colorblindMode);
+    setHasHydratedDraft(true);
+  }, []);
+
   const payload = useMemo(
     () => ({
       startDate,
@@ -93,18 +107,26 @@ export default function Home() {
   }, [payload]);
 
   useEffect(() => {
-    const draft = loadScheduleDraft();
-    if (!draft) {
-      setHasHydratedDraft(true);
-      return;
+    hydrateFromDraft();
+  }, [hydrateFromDraft]);
+
+  useEffect(() => {
+    function handlePageSync(): void {
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+      hydrateFromDraft();
     }
-    setStartDate(draft.startDate);
-    setEndDate(draft.endDate);
-    setHolidayCountry(draft.holidayCountry);
-    setMembers(draft.members);
-    setColorblindMode(draft.colorblindMode);
-    setHasHydratedDraft(true);
-  }, []);
+
+    window.addEventListener("focus", handlePageSync);
+    window.addEventListener("pageshow", handlePageSync);
+    document.addEventListener("visibilitychange", handlePageSync);
+    return () => {
+      window.removeEventListener("focus", handlePageSync);
+      window.removeEventListener("pageshow", handlePageSync);
+      document.removeEventListener("visibilitychange", handlePageSync);
+    };
+  }, [hydrateFromDraft]);
 
   useEffect(() => {
     if (!hasHydratedDraft) return;

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -46,6 +46,35 @@ function defaultMembers() {
   ];
 }
 
+function ensureMinimumMembers(
+  members: Array<{ id: string; name: string; unavailableDates: string[] }>,
+) {
+  if (members.length >= 2) {
+    return members;
+  }
+  const fallback = defaultMembers();
+  if (members.length === 1) {
+    return [members[0], fallback[1]];
+  }
+  return fallback;
+}
+
+function getCurrentDraft() {
+  const draft = loadScheduleDraft();
+  if (draft) {
+    return draft;
+  }
+
+  const defaults = defaultRange();
+  return {
+    startDate: defaults.start,
+    endDate: defaults.end,
+    holidayCountry: "US" as const,
+    members: defaultMembers(),
+    colorblindMode: false,
+  };
+}
+
 export default function TeamsPage() {
   const { status: sessionStatus } = useSession();
   const [pending, startTransition] = useTransition();
@@ -54,22 +83,6 @@ export default function TeamsPage() {
   const [teamError, setTeamError] = useState<string | null>(null);
   const [teamNotice, setTeamNotice] = useState<string | null>(null);
   const [memberEmail, setMemberEmail] = useState("");
-
-  const localDraft = useMemo(() => {
-    const draft = loadScheduleDraft();
-    if (draft) {
-      return draft;
-    }
-
-    const defaults = defaultRange();
-    return {
-      startDate: defaults.start,
-      endDate: defaults.end,
-      holidayCountry: "US" as const,
-      members: defaultMembers(),
-      colorblindMode: false,
-    };
-  }, []);
 
   useEffect(() => {
     if (sessionStatus !== "authenticated") {
@@ -121,7 +134,7 @@ export default function TeamsPage() {
     startTransition(async () => {
       const response = await saveTeamMembersAction({
         teamId: selectedTeamId,
-        members: localDraft.members.map((member) => ({
+        members: getCurrentDraft().members.map((member) => ({
           id: member.id,
           name: member.name.trim(),
           unavailableDates: member.unavailableDates,
@@ -139,7 +152,7 @@ export default function TeamsPage() {
 
       setTeamNotice("Saved current scheduler members and availability to this team.");
     });
-  }, [canSaveFromDraft, localDraft.members, selectedTeamId]);
+  }, [canSaveFromDraft, selectedTeamId]);
 
   const loadToSchedulerDraft = useCallback(() => {
     if (!selectedTeamId) {
@@ -157,18 +170,18 @@ export default function TeamsPage() {
       }
 
       saveScheduleDraft({
-        ...localDraft,
-        members:
-          response.data.members.length >= 2 ? response.data.members : defaultMembers(),
+        ...getCurrentDraft(),
+        members: ensureMinimumMembers(response.data.members),
       });
 
-      setTeamNotice(
-        response.data.members.length > 0
-          ? "Loaded team availability into your scheduler draft. Open Home to continue."
-          : "This team has no saved availability yet.",
-      );
+      if (response.data.members.length > 0) {
+        window.location.assign("/");
+        return;
+      }
+
+      setTeamNotice("This team has no saved availability yet.");
     });
-  }, [localDraft, selectedTeamId]);
+  }, [selectedTeamId]);
 
   const addMemberByEmail = useCallback(() => {
     if (!selectedTeamId) {

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 
 import {
+  addTeamMemberByEmailAction,
   listTeamsAction,
   loadTeamMembersAction,
   saveTeamMembersAction,
@@ -15,6 +16,7 @@ import { ThemeSelector } from "@/components/theme-selector";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -51,6 +53,7 @@ export default function TeamsPage() {
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [teamError, setTeamError] = useState<string | null>(null);
   const [teamNotice, setTeamNotice] = useState<string | null>(null);
+  const [memberEmail, setMemberEmail] = useState("");
 
   const localDraft = useMemo(() => {
     const draft = loadScheduleDraft();
@@ -167,6 +170,46 @@ export default function TeamsPage() {
     });
   }, [localDraft, selectedTeamId]);
 
+  const addMemberByEmail = useCallback(() => {
+    if (!selectedTeamId) {
+      setTeamError("Select a team before adding a member.");
+      return;
+    }
+    if (!canSaveFromDraft) {
+      setTeamError("Your role does not allow adding members to this team.");
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTransition(async () => {
+      const response = await addTeamMemberByEmailAction({
+        teamId: selectedTeamId,
+        email: memberEmail.trim(),
+      });
+
+      if (!response.ok) {
+        if (response.code === "target_user_not_found") {
+          setTeamError("No account exists with that email. Ask the user to register first.");
+          return;
+        }
+        if (response.code === "already_member") {
+          setTeamError("That account is already a member of this team.");
+          return;
+        }
+        setTeamError(response.error);
+        return;
+      }
+
+      setMemberEmail("");
+      setTeamNotice(`Added ${response.data.email} as a member.`);
+      const refreshed = await listTeamsAction();
+      if (refreshed.ok) {
+        setTeams(refreshed.data);
+      }
+    });
+  }, [canSaveFromDraft, memberEmail, selectedTeamId]);
+
   return (
     <div className="bg-background min-h-full">
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10 md:px-6">
@@ -238,6 +281,32 @@ export default function TeamsPage() {
                 ) : null}
                 {teams.length === 0 ? (
                   <p className="text-muted-foreground text-sm">You are not in any teams yet.</p>
+                ) : null}
+                {teams.length > 0 ? (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <Input
+                      type="email"
+                      value={memberEmail}
+                      onChange={(event) => setMemberEmail(event.target.value)}
+                      placeholder="Add existing user by email"
+                      disabled={pending || !selectedTeamId || !canSaveFromDraft}
+                      className="sm:w-80"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={addMemberByEmail}
+                      disabled={
+                        pending ||
+                        !selectedTeamId ||
+                        !canSaveFromDraft ||
+                        memberEmail.trim().length === 0
+                      }
+                    >
+                      {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                      Add member
+                    </Button>
+                  </div>
                 ) : null}
               </>
             )}

--- a/lib/team/rbac.ts
+++ b/lib/team/rbac.ts
@@ -1,19 +1,25 @@
 import { TeamRole } from "@prisma/client";
 
-export type TeamPermission = "team:roster:read" | "team:roster:write";
+export type TeamPermission =
+  | "team:roster:read"
+  | "team:roster:write"
+  | "team:members:write";
 
 const rolePermissionMatrix: Record<TeamRole, Record<TeamPermission, boolean>> = {
   [TeamRole.OWNER]: {
     "team:roster:read": true,
     "team:roster:write": true,
+    "team:members:write": true,
   },
   [TeamRole.ADMIN]: {
     "team:roster:read": true,
     "team:roster:write": true,
+    "team:members:write": true,
   },
   [TeamRole.MEMBER]: {
     "team:roster:read": true,
     "team:roster:write": false,
+    "team:members:write": false,
   },
 };
 

--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -55,9 +55,28 @@ export class TeamPermissionDeniedError extends Error {
   }
 }
 
+export class TeamMemberTargetNotFoundError extends Error {
+  constructor() {
+    super("No account exists with that email.");
+    this.name = "TeamMemberTargetNotFoundError";
+  }
+}
+
+export class TeamMemberAlreadyExistsError extends Error {
+  constructor() {
+    super("This user is already a member of the selected team.");
+    this.name = "TeamMemberAlreadyExistsError";
+  }
+}
+
 const saveTeamMembersInputSchema = z.object({
   teamId: z.string().min(1, "Team is required."),
   members: z.array(scheduleMemberSchema).min(2, "Add at least two team members."),
+});
+
+const addTeamMemberByEmailInputSchema = z.object({
+  teamId: z.string().min(1, "Team is required."),
+  email: z.string().trim().email("Provide a valid account email."),
 });
 
 export async function createTeamForCurrentUser(
@@ -191,6 +210,59 @@ export async function loadTeamMembersForCurrentUser(
   return {
     teamId: parsedTeamId,
     members,
+  };
+}
+
+export async function addTeamMemberByEmailForCurrentUser(
+  raw: unknown,
+): Promise<{ teamId: string; userId: string; email: string; role: TeamRole }> {
+  const userId = await requireUserId();
+  const parsed = addTeamMemberByEmailInputSchema.parse(raw);
+
+  await assertTeamPermission(parsed.teamId, userId, "team:members:write");
+
+  const email = parsed.email.toLowerCase();
+  const targetUser = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, email: true },
+  });
+
+  if (!targetUser) {
+    throw new TeamMemberTargetNotFoundError();
+  }
+
+  const existingMembership = await prisma.teamMembership.findUnique({
+    where: {
+      teamId_userId: {
+        teamId: parsed.teamId,
+        userId: targetUser.id,
+      },
+    },
+    select: { id: true },
+  });
+
+  if (existingMembership) {
+    throw new TeamMemberAlreadyExistsError();
+  }
+
+  const membership = await prisma.teamMembership.create({
+    data: {
+      teamId: parsed.teamId,
+      userId: targetUser.id,
+      role: TeamRole.MEMBER,
+    },
+    select: {
+      teamId: true,
+      userId: true,
+      role: true,
+    },
+  });
+
+  return {
+    teamId: membership.teamId,
+    userId: membership.userId,
+    email: targetUser.email,
+    role: membership.role,
   };
 }
 

--- a/tests/team-rbac.test.ts
+++ b/tests/team-rbac.test.ts
@@ -11,10 +11,13 @@ describe("team role permission matrix", () => {
   }> = [
     { role: TeamRole.OWNER, permission: "team:roster:read", allowed: true },
     { role: TeamRole.OWNER, permission: "team:roster:write", allowed: true },
+    { role: TeamRole.OWNER, permission: "team:members:write", allowed: true },
     { role: TeamRole.ADMIN, permission: "team:roster:read", allowed: true },
     { role: TeamRole.ADMIN, permission: "team:roster:write", allowed: true },
+    { role: TeamRole.ADMIN, permission: "team:members:write", allowed: true },
     { role: TeamRole.MEMBER, permission: "team:roster:read", allowed: true },
     { role: TeamRole.MEMBER, permission: "team:roster:write", allowed: false },
+    { role: TeamRole.MEMBER, permission: "team:members:write", allowed: false },
   ];
 
   for (const entry of matrix) {

--- a/tests/team-service.integration.test.ts
+++ b/tests/team-service.integration.test.ts
@@ -8,8 +8,12 @@ const { authMock, prismaMock } = vi.hoisted(() => ({
     team: {
       findMany: vi.fn(),
     },
+    user: {
+      findUnique: vi.fn(),
+    },
     teamMembership: {
       findUnique: vi.fn(),
+      create: vi.fn(),
     },
     teamRoster: {
       upsert: vi.fn(),
@@ -27,9 +31,12 @@ vi.mock("@/lib/db", () => ({
 }));
 
 import {
+  TeamMemberAlreadyExistsError,
+  TeamMemberTargetNotFoundError,
   TeamAccessDeniedError,
   TeamPermissionDeniedError,
   UnauthorizedTeamAccessError,
+  addTeamMemberByEmailForCurrentUser,
   createTeamForCurrentUser,
   loadTeamMembersForCurrentUser,
   listTeamsForCurrentUser,
@@ -339,5 +346,81 @@ describe("team service integration behaviors", () => {
       expect(schedule.data.assignments.length).toBeGreaterThan(0);
       expect(schedule.data.report).toHaveLength(2);
     }
+  });
+
+  it("adds existing users to a team by email when caller has permission", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_admin" },
+    });
+    prismaMock.teamMembership.findUnique
+      .mockResolvedValueOnce({ role: "ADMIN" })
+      .mockResolvedValueOnce(null);
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "user_target",
+      email: "member@example.com",
+    });
+    prismaMock.teamMembership.create.mockResolvedValue({
+      teamId: "team_1",
+      userId: "user_target",
+      role: "MEMBER",
+    });
+
+    const result = await addTeamMemberByEmailForCurrentUser({
+      teamId: "team_1",
+      email: " MEMBER@example.com ",
+    });
+
+    expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "member@example.com" },
+      select: { id: true, email: true },
+    });
+    expect(prismaMock.teamMembership.create).toHaveBeenCalledWith({
+      data: {
+        teamId: "team_1",
+        userId: "user_target",
+        role: "MEMBER",
+      },
+      select: {
+        teamId: true,
+        userId: true,
+        role: true,
+      },
+    });
+    expect(result.email).toBe("member@example.com");
+  });
+
+  it("fails to add member when target email account does not exist", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_admin" },
+    });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "OWNER" });
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(
+      addTeamMemberByEmailForCurrentUser({
+        teamId: "team_1",
+        email: "missing@example.com",
+      }),
+    ).rejects.toBeInstanceOf(TeamMemberTargetNotFoundError);
+  });
+
+  it("fails to add member when user is already in team", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user_admin" },
+    });
+    prismaMock.teamMembership.findUnique
+      .mockResolvedValueOnce({ role: "OWNER" })
+      .mockResolvedValueOnce({ id: "membership_1" });
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "user_target",
+      email: "member@example.com",
+    });
+
+    await expect(
+      addTeamMemberByEmailForCurrentUser({
+        teamId: "team_1",
+        email: "member@example.com",
+      }),
+    ).rejects.toBeInstanceOf(TeamMemberAlreadyExistsError);
   });
 });


### PR DESCRIPTION
## Summary
- add owner/admin-only service and action to add existing accounts to a team by email
- validate target account existence and prevent duplicate memberships with clear server + UI feedback
- add integration and RBAC test coverage for success, missing-email account, and duplicate cases

## Test plan
- [x] Run `npm run test`

Closes #17