### PR TITLE
feat(team): team management CRUD and role controls

### DIFF
--- a/app/actions/team.ts
+++ b/app/actions/team.ts
@@ -3,15 +3,24 @@
 import { ZodError } from "zod";
 
 import {
+  TeamMemberNotFoundError,
+  TeamOwnerRoleInvariantError,
   TeamMemberAlreadyExistsError,
   TeamMemberTargetNotFoundError,
   TeamAccessDeniedError,
   TeamPermissionDeniedError,
   UnauthorizedTeamAccessError,
   addTeamMemberByEmailForCurrentUser,
+  createTeamForCurrentUser,
+  deleteTeamForCurrentUser,
   listTeamsForCurrentUser,
+  listTeamMembersForCurrentUser,
   loadTeamMembersForCurrentUser,
+  removeTeamMemberForCurrentUser,
   saveTeamMembersForCurrentUser,
+  updateTeamForCurrentUser,
+  updateTeamMemberRoleForCurrentUser,
+  type TeamMemberSummary,
   type TeamSummary,
 } from "@/lib/team/service";
 import type { ScheduleMember } from "@/lib/schedule/types";
@@ -24,7 +33,9 @@ type TeamActionError = {
     | "not_member"
     | "forbidden"
     | "target_user_not_found"
-    | "already_member";
+    | "already_member"
+    | "member_not_found"
+    | "owner_invariant";
   fieldErrors?: Record<string, string[]>;
 };
 
@@ -39,6 +50,39 @@ export async function listTeamsAction(): Promise<
   try {
     const teams = await listTeamsForCurrentUser();
     return { ok: true, data: teams };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+export async function createTeamAction(raw: unknown): Promise<
+  TeamActionSuccess<TeamSummary> | TeamActionError
+> {
+  try {
+    const team = await createTeamForCurrentUser(raw);
+    return { ok: true, data: team };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+export async function updateTeamAction(raw: unknown): Promise<
+  TeamActionSuccess<TeamSummary> | TeamActionError
+> {
+  try {
+    const team = await updateTeamForCurrentUser(raw);
+    return { ok: true, data: team };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+export async function deleteTeamAction(raw: unknown): Promise<
+  TeamActionSuccess<{ teamId: string }> | TeamActionError
+> {
+  try {
+    const deleted = await deleteTeamForCurrentUser(raw);
+    return { ok: true, data: deleted };
   } catch (error) {
     return toTeamActionError(error);
   }
@@ -77,6 +121,39 @@ export async function addTeamMemberByEmailAction(raw: unknown): Promise<
   }
 }
 
+export async function listTeamMembersAction(teamId: string): Promise<
+  TeamActionSuccess<TeamMemberSummary[]> | TeamActionError
+> {
+  try {
+    const members = await listTeamMembersForCurrentUser(teamId);
+    return { ok: true, data: members };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+export async function removeTeamMemberAction(raw: unknown): Promise<
+  TeamActionSuccess<{ teamId: string; userId: string }> | TeamActionError
+> {
+  try {
+    const deleted = await removeTeamMemberForCurrentUser(raw);
+    return { ok: true, data: deleted };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
+export async function updateTeamMemberRoleAction(raw: unknown): Promise<
+  TeamActionSuccess<{ teamId: string; userId: string; role: string }> | TeamActionError
+> {
+  try {
+    const updated = await updateTeamMemberRoleForCurrentUser(raw);
+    return { ok: true, data: updated };
+  } catch (error) {
+    return toTeamActionError(error);
+  }
+}
+
 function toTeamActionError(error: unknown): TeamActionError {
   if (
     error instanceof UnauthorizedTeamAccessError
@@ -98,6 +175,14 @@ function toTeamActionError(error: unknown): TeamActionError {
 
   if (error instanceof TeamMemberAlreadyExistsError) {
     return { ok: false, error: error.message, code: "already_member" };
+  }
+
+  if (error instanceof TeamMemberNotFoundError) {
+    return { ok: false, error: error.message, code: "member_not_found" };
+  }
+
+  if (error instanceof TeamOwnerRoleInvariantError) {
+    return { ok: false, error: error.message, code: "owner_invariant" };
   }
 
   if (error instanceof ZodError) {

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -4,12 +4,19 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
+import { TeamRole } from "@prisma/client";
 
 import {
   addTeamMemberByEmailAction,
+  createTeamAction,
+  deleteTeamAction,
   listTeamsAction,
+  listTeamMembersAction,
   loadTeamMembersAction,
+  removeTeamMemberAction,
   saveTeamMembersAction,
+  updateTeamAction,
+  updateTeamMemberRoleAction,
 } from "@/app/actions/team";
 import { AccountCard } from "@/components/auth/account-card";
 import { ThemeSelector } from "@/components/theme-selector";
@@ -27,7 +34,7 @@ import {
 import { addDays, formatISODateOnly } from "@/lib/schedule/dates";
 import { loadScheduleDraft, saveScheduleDraft } from "@/lib/schedule/draft-storage";
 import { canSaveTeamRoster, teamRosterPermissionHint } from "@/lib/team/roster-ui";
-import type { TeamSummary } from "@/lib/team/service";
+import type { TeamMemberSummary, TeamSummary } from "@/lib/team/service";
 
 function defaultRange(): { start: string; end: string } {
   const t = new Date();
@@ -83,12 +90,12 @@ export default function TeamsPage() {
   const [teamError, setTeamError] = useState<string | null>(null);
   const [teamNotice, setTeamNotice] = useState<string | null>(null);
   const [memberEmail, setMemberEmail] = useState("");
+  const [newTeamName, setNewTeamName] = useState("");
+  const [renameTeamName, setRenameTeamName] = useState("");
+  const [teamMembers, setTeamMembers] = useState<TeamMemberSummary[]>([]);
 
   useEffect(() => {
     if (sessionStatus !== "authenticated") {
-      setTeams([]);
-      setSelectedTeamId(null);
-      setTeamError(null);
       return;
     }
 
@@ -111,6 +118,22 @@ export default function TeamsPage() {
     });
   }, [sessionStatus]);
 
+  useEffect(() => {
+    if (sessionStatus !== "authenticated" || !selectedTeamId) {
+      return;
+    }
+
+    startTransition(async () => {
+      const response = await listTeamMembersAction(selectedTeamId);
+      if (!response.ok) {
+        setTeamMembers([]);
+        setTeamError(response.error);
+        return;
+      }
+      setTeamMembers(response.data);
+    });
+  }, [selectedTeamId, sessionStatus]);
+
   const selectedTeam = useMemo(
     () => teams.find((team) => team.id === selectedTeamId) ?? null,
     [selectedTeamId, teams],
@@ -118,6 +141,28 @@ export default function TeamsPage() {
 
   const canSaveFromDraft = canSaveTeamRoster(selectedTeam);
   const rosterPermissionHint = teamRosterPermissionHint(selectedTeam);
+  const canManageTeamDetails = selectedTeam
+    ? selectedTeam.currentUserRole === "OWNER" || selectedTeam.currentUserRole === "ADMIN"
+    : false;
+  const canDeleteTeam = selectedTeam?.currentUserRole === "OWNER";
+  const canManageMembers = canSaveFromDraft;
+  const canUpdateMemberRoles = selectedTeam?.currentUserRole === "OWNER";
+
+  const refreshTeamsAndSelection = useCallback(async () => {
+    const refreshed = await listTeamsAction();
+    if (!refreshed.ok) {
+      setTeamError(refreshed.error);
+      return false;
+    }
+
+    setTeams(refreshed.data);
+    setSelectedTeamId((current) =>
+      current && refreshed.data.some((team) => team.id === current)
+        ? current
+        : (refreshed.data[0]?.id ?? null),
+    );
+    return true;
+  }, []);
 
   const saveCurrentDraft = useCallback(() => {
     if (!selectedTeamId) {
@@ -216,12 +261,120 @@ export default function TeamsPage() {
 
       setMemberEmail("");
       setTeamNotice(`Added ${response.data.email} as a member.`);
-      const refreshed = await listTeamsAction();
-      if (refreshed.ok) {
-        setTeams(refreshed.data);
-      }
+      await refreshTeamsAndSelection();
     });
-  }, [canSaveFromDraft, memberEmail, selectedTeamId]);
+  }, [canSaveFromDraft, memberEmail, refreshTeamsAndSelection, selectedTeamId]);
+
+  const createTeam = useCallback(() => {
+    const name = newTeamName.trim();
+    if (name.length === 0) {
+      setTeamError("Enter a team name before creating.");
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTransition(async () => {
+      const response = await createTeamAction({ name });
+      if (!response.ok) {
+        setTeamError(response.error);
+        return;
+      }
+      setNewTeamName("");
+      setTeamNotice(`Created team ${response.data.name}.`);
+      await refreshTeamsAndSelection();
+      setSelectedTeamId(response.data.id);
+    });
+  }, [newTeamName, refreshTeamsAndSelection]);
+
+  const renameSelectedTeam = useCallback(() => {
+    if (!selectedTeamId) {
+      setTeamError("Select a team before renaming.");
+      return;
+    }
+
+    const name = renameTeamName.trim();
+    if (name.length === 0) {
+      setTeamError("Team name is required.");
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTransition(async () => {
+      const response = await updateTeamAction({ teamId: selectedTeamId, name });
+      if (!response.ok) {
+        setTeamError(response.error);
+        return;
+      }
+      setTeamNotice(`Renamed team to ${response.data.name}.`);
+      await refreshTeamsAndSelection();
+    });
+  }, [refreshTeamsAndSelection, renameTeamName, selectedTeamId]);
+
+  const deleteSelectedTeam = useCallback(() => {
+    if (!selectedTeamId || !selectedTeam) {
+      setTeamError("Select a team before deleting.");
+      return;
+    }
+    if (!window.confirm(`Delete team "${selectedTeam.name}"? This cannot be undone.`)) {
+      return;
+    }
+
+    setTeamError(null);
+    setTeamNotice(null);
+    startTransition(async () => {
+      const response = await deleteTeamAction({ teamId: selectedTeamId });
+      if (!response.ok) {
+        setTeamError(response.error);
+        return;
+      }
+      setTeamNotice("Deleted team.");
+      await refreshTeamsAndSelection();
+    });
+  }, [refreshTeamsAndSelection, selectedTeam, selectedTeamId]);
+
+  const removeMember = useCallback(
+    (userId: string) => {
+      if (!selectedTeamId) return;
+      startTransition(async () => {
+        const response = await removeTeamMemberAction({ teamId: selectedTeamId, userId });
+        if (!response.ok) {
+          setTeamError(response.error);
+          return;
+        }
+        await refreshTeamsAndSelection();
+        const membersResponse = await listTeamMembersAction(selectedTeamId);
+        if (membersResponse.ok) {
+          setTeamMembers(membersResponse.data);
+        }
+      });
+    },
+    [refreshTeamsAndSelection, selectedTeamId],
+  );
+
+  const updateMemberRole = useCallback(
+    (userId: string, role: TeamRole) => {
+      if (!selectedTeamId) return;
+      startTransition(async () => {
+        const response = await updateTeamMemberRoleAction({
+          teamId: selectedTeamId,
+          userId,
+          role,
+        });
+        if (!response.ok) {
+          setTeamError(response.error);
+          return;
+        }
+        const membersResponse = await listTeamMembersAction(selectedTeamId);
+        if (membersResponse.ok) {
+          setTeamMembers(membersResponse.data);
+        }
+        await refreshTeamsAndSelection();
+      });
+    },
+    [refreshTeamsAndSelection, selectedTeamId],
+  );
 
   return (
     <div className="bg-background min-h-full">
@@ -253,9 +406,30 @@ export default function TeamsPage() {
             ) : (
               <>
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <Input
+                    value={newTeamName}
+                    onChange={(event) => setNewTeamName(event.target.value)}
+                    placeholder="New team name"
+                    disabled={pending}
+                    className="sm:w-80"
+                  />
+                  <Button
+                    type="button"
+                    onClick={createTeam}
+                    disabled={pending || newTeamName.trim().length === 0}
+                  >
+                    {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                    Create team
+                  </Button>
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                   <Select
                     value={selectedTeamId ?? ""}
-                    onValueChange={(value) => setSelectedTeamId(value)}
+                    onValueChange={(value) => {
+                      setSelectedTeamId(value);
+                      const team = teams.find((entry) => entry.id === value);
+                      setRenameTeamName(team?.name ?? "");
+                    }}
                     disabled={teams.length === 0}
                   >
                     <SelectTrigger className="w-full sm:w-80">
@@ -319,6 +493,94 @@ export default function TeamsPage() {
                       {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
                       Add member
                     </Button>
+                  </div>
+                ) : null}
+                {selectedTeam ? (
+                  <div className="space-y-3 rounded-md border p-3">
+                    <p className="text-muted-foreground text-sm">
+                      Team details: role <strong>{selectedTeam.currentUserRole}</strong>, members{" "}
+                      <strong>{selectedTeam.memberCount}</strong>.
+                    </p>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <Input
+                        value={renameTeamName}
+                        onChange={(event) => setRenameTeamName(event.target.value)}
+                        disabled={pending || !canManageTeamDetails}
+                        className="sm:w-80"
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={renameSelectedTeam}
+                        disabled={
+                          pending ||
+                          !canManageTeamDetails ||
+                          renameTeamName.trim().length === 0
+                        }
+                      >
+                        Rename team
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={deleteSelectedTeam}
+                        disabled={pending || !canDeleteTeam}
+                      >
+                        Delete team
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+                {selectedTeam ? (
+                  <div className="space-y-2 rounded-md border p-3">
+                    <p className="text-sm font-medium">Members</p>
+                    {teamMembers.length === 0 ? (
+                      <p className="text-muted-foreground text-sm">No members found.</p>
+                    ) : (
+                      <ul className="space-y-2">
+                        {teamMembers.map((member) => (
+                          <li
+                            key={member.userId}
+                            className="flex flex-col gap-2 rounded border p-2 sm:flex-row sm:items-center sm:justify-between"
+                          >
+                            <div className="text-sm">{member.email}</div>
+                            <div className="flex items-center gap-2">
+                              <Select
+                                value={member.role}
+                                onValueChange={(value) =>
+                                  updateMemberRole(member.userId, value as TeamRole)
+                                }
+                                disabled={
+                                  pending ||
+                                  !canUpdateMemberRoles ||
+                                  member.role === "OWNER"
+                                }
+                              >
+                                <SelectTrigger className="w-36">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="ADMIN">ADMIN</SelectItem>
+                                  <SelectItem value="MEMBER">MEMBER</SelectItem>
+                                </SelectContent>
+                              </Select>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                onClick={() => removeMember(member.userId)}
+                                disabled={
+                                  pending ||
+                                  !canManageMembers ||
+                                  member.role === "OWNER"
+                                }
+                              >
+                                Remove
+                              </Button>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </div>
                 ) : null}
               </>

--- a/lib/team/rbac.ts
+++ b/lib/team/rbac.ts
@@ -3,23 +3,35 @@ import { TeamRole } from "@prisma/client";
 export type TeamPermission =
   | "team:roster:read"
   | "team:roster:write"
-  | "team:members:write";
+  | "team:members:write"
+  | "team:update"
+  | "team:delete"
+  | "team:members:role:update";
 
 const rolePermissionMatrix: Record<TeamRole, Record<TeamPermission, boolean>> = {
   [TeamRole.OWNER]: {
     "team:roster:read": true,
     "team:roster:write": true,
     "team:members:write": true,
+    "team:update": true,
+    "team:delete": true,
+    "team:members:role:update": true,
   },
   [TeamRole.ADMIN]: {
     "team:roster:read": true,
     "team:roster:write": true,
     "team:members:write": true,
+    "team:update": true,
+    "team:delete": false,
+    "team:members:role:update": false,
   },
   [TeamRole.MEMBER]: {
     "team:roster:read": true,
     "team:roster:write": false,
     "team:members:write": false,
+    "team:update": false,
+    "team:delete": false,
+    "team:members:role:update": false,
   },
 };
 

--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -69,6 +69,20 @@ export class TeamMemberAlreadyExistsError extends Error {
   }
 }
 
+export class TeamMemberNotFoundError extends Error {
+  constructor() {
+    super("This user is not a member of the selected team.");
+    this.name = "TeamMemberNotFoundError";
+  }
+}
+
+export class TeamOwnerRoleInvariantError extends Error {
+  constructor() {
+    super("Owner membership cannot be modified by this action.");
+    this.name = "TeamOwnerRoleInvariantError";
+  }
+}
+
 const saveTeamMembersInputSchema = z.object({
   teamId: z.string().min(1, "Team is required."),
   members: z.array(scheduleMemberSchema).min(2, "Add at least two team members."),
@@ -78,6 +92,32 @@ const addTeamMemberByEmailInputSchema = z.object({
   teamId: z.string().min(1, "Team is required."),
   email: z.string().trim().email("Provide a valid account email."),
 });
+
+const updateTeamInputSchema = z.object({
+  teamId: z.string().min(1, "Team is required."),
+  name: z.string().trim().min(1, "Team name is required."),
+});
+
+const deleteTeamInputSchema = z.object({
+  teamId: z.string().min(1, "Team is required."),
+});
+
+const removeTeamMemberInputSchema = z.object({
+  teamId: z.string().min(1, "Team is required."),
+  userId: z.string().min(1, "Member user id is required."),
+});
+
+const updateTeamMemberRoleInputSchema = z.object({
+  teamId: z.string().min(1, "Team is required."),
+  userId: z.string().min(1, "Member user id is required."),
+  role: z.nativeEnum(TeamRole),
+});
+
+export type TeamMemberSummary = {
+  userId: string;
+  email: string;
+  role: TeamRole;
+};
 
 export async function createTeamForCurrentUser(
   raw: unknown,
@@ -266,6 +306,161 @@ export async function addTeamMemberByEmailForCurrentUser(
   };
 }
 
+export async function updateTeamForCurrentUser(raw: unknown): Promise<TeamSummary> {
+  const userId = await requireUserId();
+  const parsed = updateTeamInputSchema.parse(raw);
+  await assertTeamPermission(parsed.teamId, userId, "team:update");
+
+  const team = await prisma.team.update({
+    where: { id: parsed.teamId },
+    data: { name: parsed.name },
+    include: {
+      memberships: {
+        select: {
+          userId: true,
+          role: true,
+        },
+      },
+    },
+  });
+
+  return toTeamSummary(team, userId);
+}
+
+export async function deleteTeamForCurrentUser(raw: unknown): Promise<{ teamId: string }> {
+  const userId = await requireUserId();
+  const parsed = deleteTeamInputSchema.parse(raw);
+  await assertTeamPermission(parsed.teamId, userId, "team:delete");
+
+  await prisma.team.delete({
+    where: { id: parsed.teamId },
+  });
+
+  return { teamId: parsed.teamId };
+}
+
+export async function listTeamMembersForCurrentUser(
+  teamId: string,
+): Promise<TeamMemberSummary[]> {
+  const userId = await requireUserId();
+  const parsedTeamId = z.string().min(1, "Team is required.").parse(teamId);
+  await assertTeamPermission(parsedTeamId, userId, "team:roster:read");
+
+  const members = await prisma.teamMembership.findMany({
+    where: { teamId: parsedTeamId },
+    select: {
+      userId: true,
+      role: true,
+      user: {
+        select: {
+          email: true,
+        },
+      },
+    },
+    orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+  });
+
+  return members.map((member) => ({
+    userId: member.userId,
+    email: member.user.email,
+    role: member.role,
+  }));
+}
+
+export async function removeTeamMemberForCurrentUser(
+  raw: unknown,
+): Promise<{ teamId: string; userId: string }> {
+  const actorUserId = await requireUserId();
+  const parsed = removeTeamMemberInputSchema.parse(raw);
+  const actorMembership = await assertTeamPermission(
+    parsed.teamId,
+    actorUserId,
+    "team:members:write",
+  );
+
+  const targetMembership = await prisma.teamMembership.findUnique({
+    where: {
+      teamId_userId: {
+        teamId: parsed.teamId,
+        userId: parsed.userId,
+      },
+    },
+    select: { role: true },
+  });
+
+  if (!targetMembership) {
+    throw new TeamMemberNotFoundError();
+  }
+  if (targetMembership.role === TeamRole.OWNER) {
+    throw new TeamOwnerRoleInvariantError();
+  }
+  if (actorMembership.role !== TeamRole.OWNER && targetMembership.role === TeamRole.ADMIN) {
+    throw new TeamPermissionDeniedError();
+  }
+
+  await prisma.teamMembership.delete({
+    where: {
+      teamId_userId: {
+        teamId: parsed.teamId,
+        userId: parsed.userId,
+      },
+    },
+  });
+
+  return { teamId: parsed.teamId, userId: parsed.userId };
+}
+
+export async function updateTeamMemberRoleForCurrentUser(
+  raw: unknown,
+): Promise<{ teamId: string; userId: string; role: TeamRole }> {
+  const actorUserId = await requireUserId();
+  const parsed = updateTeamMemberRoleInputSchema.parse(raw);
+  const actorMembership = await assertTeamPermission(
+    parsed.teamId,
+    actorUserId,
+    "team:members:role:update",
+  );
+
+  if (parsed.role === TeamRole.OWNER) {
+    throw new TeamOwnerRoleInvariantError();
+  }
+
+  const targetMembership = await prisma.teamMembership.findUnique({
+    where: {
+      teamId_userId: {
+        teamId: parsed.teamId,
+        userId: parsed.userId,
+      },
+    },
+    select: { role: true },
+  });
+
+  if (!targetMembership) {
+    throw new TeamMemberNotFoundError();
+  }
+  if (targetMembership.role === TeamRole.OWNER || parsed.userId === actorUserId) {
+    throw new TeamOwnerRoleInvariantError();
+  }
+  if (actorMembership.role !== TeamRole.OWNER) {
+    throw new TeamPermissionDeniedError();
+  }
+
+  return prisma.teamMembership.update({
+    where: {
+      teamId_userId: {
+        teamId: parsed.teamId,
+        userId: parsed.userId,
+      },
+    },
+    data: { role: parsed.role },
+    select: {
+      teamId: true,
+      userId: true,
+      role: true,
+    },
+  });
+}
+
 async function requireUserId(): Promise<string> {
   const session = await auth();
   const user = session?.user as { id?: string; email?: string } | undefined;
@@ -290,7 +485,7 @@ async function assertTeamPermission(
   teamId: string,
   userId: string,
   permission: TeamPermission,
-): Promise<void> {
+): Promise<{ role: TeamRole }> {
   const membership = await prisma.teamMembership.findUnique({
     where: {
       teamId_userId: {
@@ -308,6 +503,8 @@ async function assertTeamPermission(
   if (!canTeamRole(membership.role, permission)) {
     throw new TeamPermissionDeniedError();
   }
+
+  return membership;
 }
 
 function toTeamSummary(team: TeamWithMemberships, currentUserId: string): TeamSummary {

--- a/tests/team-rbac.test.ts
+++ b/tests/team-rbac.test.ts
@@ -12,12 +12,21 @@ describe("team role permission matrix", () => {
     { role: TeamRole.OWNER, permission: "team:roster:read", allowed: true },
     { role: TeamRole.OWNER, permission: "team:roster:write", allowed: true },
     { role: TeamRole.OWNER, permission: "team:members:write", allowed: true },
+    { role: TeamRole.OWNER, permission: "team:update", allowed: true },
+    { role: TeamRole.OWNER, permission: "team:delete", allowed: true },
+    { role: TeamRole.OWNER, permission: "team:members:role:update", allowed: true },
     { role: TeamRole.ADMIN, permission: "team:roster:read", allowed: true },
     { role: TeamRole.ADMIN, permission: "team:roster:write", allowed: true },
     { role: TeamRole.ADMIN, permission: "team:members:write", allowed: true },
+    { role: TeamRole.ADMIN, permission: "team:update", allowed: true },
+    { role: TeamRole.ADMIN, permission: "team:delete", allowed: false },
+    { role: TeamRole.ADMIN, permission: "team:members:role:update", allowed: false },
     { role: TeamRole.MEMBER, permission: "team:roster:read", allowed: true },
     { role: TeamRole.MEMBER, permission: "team:roster:write", allowed: false },
     { role: TeamRole.MEMBER, permission: "team:members:write", allowed: false },
+    { role: TeamRole.MEMBER, permission: "team:update", allowed: false },
+    { role: TeamRole.MEMBER, permission: "team:delete", allowed: false },
+    { role: TeamRole.MEMBER, permission: "team:members:role:update", allowed: false },
   ];
 
   for (const entry of matrix) {

--- a/tests/team-service.integration.test.ts
+++ b/tests/team-service.integration.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TeamRole } from "@prisma/client";
 import { calculateSchedule } from "@/app/actions/schedule";
 
 const { authMock, prismaMock } = vi.hoisted(() => ({
@@ -7,6 +8,8 @@ const { authMock, prismaMock } = vi.hoisted(() => ({
     $transaction: vi.fn(),
     team: {
       findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
     },
     user: {
       findUnique: vi.fn(),
@@ -14,6 +17,9 @@ const { authMock, prismaMock } = vi.hoisted(() => ({
     teamMembership: {
       findUnique: vi.fn(),
       create: vi.fn(),
+      findMany: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
     },
     teamRoster: {
       upsert: vi.fn(),
@@ -32,15 +38,22 @@ vi.mock("@/lib/db", () => ({
 
 import {
   TeamMemberAlreadyExistsError,
+  TeamMemberNotFoundError,
   TeamMemberTargetNotFoundError,
+  TeamOwnerRoleInvariantError,
   TeamAccessDeniedError,
   TeamPermissionDeniedError,
   UnauthorizedTeamAccessError,
   addTeamMemberByEmailForCurrentUser,
   createTeamForCurrentUser,
+  deleteTeamForCurrentUser,
+  listTeamMembersForCurrentUser,
   loadTeamMembersForCurrentUser,
   listTeamsForCurrentUser,
+  removeTeamMemberForCurrentUser,
   saveTeamMembersForCurrentUser,
+  updateTeamForCurrentUser,
+  updateTeamMemberRoleForCurrentUser,
 } from "@/lib/team/service";
 
 describe("team service integration behaviors", () => {
@@ -422,5 +435,156 @@ describe("team service integration behaviors", () => {
         email: "member@example.com",
       }),
     ).rejects.toBeInstanceOf(TeamMemberAlreadyExistsError);
+  });
+
+  it("updates team details for owner/admin roles", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_admin" } });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "ADMIN" });
+    prismaMock.team.update.mockResolvedValue({
+      id: "team_1",
+      name: "Renamed Team",
+      ownerId: "user_owner",
+      createdAt: new Date("2026-04-24T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-24T12:10:00.000Z"),
+      memberships: [
+        { userId: "user_owner", role: "OWNER" },
+        { userId: "user_admin", role: "ADMIN" },
+      ],
+    });
+
+    const updated = await updateTeamForCurrentUser({
+      teamId: "team_1",
+      name: " Renamed Team ",
+    });
+    expect(updated.name).toBe("Renamed Team");
+  });
+
+  it("allows only owner to delete team", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_owner" } });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "OWNER" });
+    prismaMock.team.delete.mockResolvedValue({ id: "team_1" });
+
+    await expect(
+      deleteTeamForCurrentUser({
+        teamId: "team_1",
+      }),
+    ).resolves.toEqual({ teamId: "team_1" });
+  });
+
+  it("denies team deletion for admin role", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_admin" } });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "ADMIN" });
+
+    await expect(
+      deleteTeamForCurrentUser({
+        teamId: "team_1",
+      }),
+    ).rejects.toBeInstanceOf(TeamPermissionDeniedError);
+  });
+
+  it("lists team members for accessible teams", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_owner" } });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "OWNER" });
+    prismaMock.teamMembership.findMany.mockResolvedValue([
+      { userId: "user_owner", role: "OWNER", user: { email: "owner@example.com" } },
+      { userId: "user_admin", role: "ADMIN", user: { email: "admin@example.com" } },
+    ]);
+
+    const members = await listTeamMembersForCurrentUser("team_1");
+    expect(members).toHaveLength(2);
+    expect(members[0]?.role).toBe("OWNER");
+  });
+
+  it("allows owner to change member roles", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_owner" } });
+    prismaMock.teamMembership.findUnique
+      .mockResolvedValueOnce({ role: "OWNER" })
+      .mockResolvedValueOnce({ role: "MEMBER" });
+    prismaMock.teamMembership.update.mockResolvedValue({
+      teamId: "team_1",
+      userId: "user_member",
+      role: TeamRole.ADMIN,
+    });
+
+    const result = await updateTeamMemberRoleForCurrentUser({
+      teamId: "team_1",
+      userId: "user_member",
+      role: TeamRole.ADMIN,
+    });
+    expect(result.role).toBe("ADMIN");
+  });
+
+  it("denies admin role updates of member roles", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_admin" } });
+    prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "ADMIN" });
+
+    await expect(
+      updateTeamMemberRoleForCurrentUser({
+        teamId: "team_1",
+        userId: "user_member",
+        role: TeamRole.ADMIN,
+      }),
+    ).rejects.toBeInstanceOf(TeamPermissionDeniedError);
+  });
+
+  it("prevents modifying owner role through member role update", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_owner" } });
+    prismaMock.teamMembership.findUnique
+      .mockResolvedValueOnce({ role: "OWNER" })
+      .mockResolvedValueOnce({ role: "OWNER" });
+
+    await expect(
+      updateTeamMemberRoleForCurrentUser({
+        teamId: "team_1",
+        userId: "user_owner",
+        role: TeamRole.MEMBER,
+      }),
+    ).rejects.toBeInstanceOf(TeamOwnerRoleInvariantError);
+  });
+
+  it("allows owner to remove non-owner members", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_owner" } });
+    prismaMock.teamMembership.findUnique
+      .mockResolvedValueOnce({ role: "OWNER" })
+      .mockResolvedValueOnce({ role: "MEMBER" });
+    prismaMock.teamMembership.delete.mockResolvedValue({});
+
+    await expect(
+      removeTeamMemberForCurrentUser({
+        teamId: "team_1",
+        userId: "user_member",
+      }),
+    ).resolves.toEqual({
+      teamId: "team_1",
+      userId: "user_member",
+    });
+  });
+
+  it("denies removing owner membership", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_owner" } });
+    prismaMock.teamMembership.findUnique
+      .mockResolvedValueOnce({ role: "OWNER" })
+      .mockResolvedValueOnce({ role: "OWNER" });
+
+    await expect(
+      removeTeamMemberForCurrentUser({
+        teamId: "team_1",
+        userId: "user_owner",
+      }),
+    ).rejects.toBeInstanceOf(TeamOwnerRoleInvariantError);
+  });
+
+  it("fails removing member when target membership does not exist", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_owner" } });
+    prismaMock.teamMembership.findUnique
+      .mockResolvedValueOnce({ role: "OWNER" })
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      removeTeamMemberForCurrentUser({
+        teamId: "team_1",
+        userId: "user_missing",
+      }),
+    ).rejects.toBeInstanceOf(TeamMemberNotFoundError);
   });
 });


### PR DESCRIPTION
## Summary
- Adds authenticated team create, update (rename), and delete with confirmation and server-side permission checks.
- Extends member management (list, add by email, remove, role updates) with owner/admin/member rules aligned to the existing RBAC matrix.
- Surfaces clear empty, error, and permission-denied states on the teams page; keeps team logic in `app/actions/team.ts` and `lib/team/service.ts`.

## Test plan
- [x] `npm test` (Vitest), including new `team-service.integration` coverage for CRUD and permission edge cases.
- [x] Manual: sign in, create a team, rename, add/remove members, delete; repeat as member vs admin vs owner where applicable.

Closes #28

Related: parent tracking issue #8.
