### PR TITLE
fix(ui): Base UI select labels, positioning, and eslint cleanup

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,9 @@ export default function Home() {
   }, [payload]);
 
   useEffect(() => {
-    hydrateFromDraft();
+    queueMicrotask(() => {
+      hydrateFromDraft();
+    });
   }, [hydrateFromDraft]);
 
   useEffect(() => {

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -36,6 +36,11 @@ import { loadScheduleDraft, saveScheduleDraft } from "@/lib/schedule/draft-stora
 import { canSaveTeamRoster, teamRosterPermissionHint } from "@/lib/team/roster-ui";
 import type { TeamMemberSummary, TeamSummary } from "@/lib/team/service";
 
+const MEMBER_ROLE_SELECT_ITEMS: { value: TeamRole; label: string }[] = [
+  { value: TeamRole.ADMIN, label: "Admin" },
+  { value: TeamRole.MEMBER, label: "Member" },
+];
+
 function defaultRange(): { start: string; end: string } {
   const t = new Date();
   const start = new Date(t.getFullYear(), t.getMonth(), t.getDate(), 12, 0, 0);
@@ -137,6 +142,11 @@ export default function TeamsPage() {
   const selectedTeam = useMemo(
     () => teams.find((team) => team.id === selectedTeamId) ?? null,
     [selectedTeamId, teams],
+  );
+
+  const teamSelectItems = useMemo(
+    () => teams.map((team) => ({ value: team.id, label: team.name })),
+    [teams],
   );
 
   const canSaveFromDraft = canSaveTeamRoster(selectedTeam);
@@ -425,6 +435,7 @@ export default function TeamsPage() {
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                   <Select
                     value={selectedTeamId ?? ""}
+                    items={teamSelectItems}
                     onValueChange={(value) => {
                       setSelectedTeamId(value);
                       const team = teams.find((entry) => entry.id === value);
@@ -432,12 +443,12 @@ export default function TeamsPage() {
                     }}
                     disabled={teams.length === 0}
                   >
-                    <SelectTrigger className="w-full sm:w-80">
+                    <SelectTrigger className="w-full min-w-0 sm:w-80">
                       <SelectValue placeholder="Select a team" />
                     </SelectTrigger>
-                    <SelectContent>
+                    <SelectContent align="start" alignItemWithTrigger={false} className="max-h-72">
                       {teams.map((team) => (
-                        <SelectItem key={team.id} value={team.id}>
+                        <SelectItem key={team.id} value={team.id} label={team.name}>
                           {team.name}
                         </SelectItem>
                       ))}
@@ -543,27 +554,41 @@ export default function TeamsPage() {
                             key={member.userId}
                             className="flex flex-col gap-2 rounded border p-2 sm:flex-row sm:items-center sm:justify-between"
                           >
-                            <div className="text-sm">{member.email}</div>
-                            <div className="flex items-center gap-2">
-                              <Select
-                                value={member.role}
-                                onValueChange={(value) =>
-                                  updateMemberRole(member.userId, value as TeamRole)
-                                }
-                                disabled={
-                                  pending ||
-                                  !canUpdateMemberRoles ||
-                                  member.role === "OWNER"
-                                }
-                              >
-                                <SelectTrigger className="w-36">
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value="ADMIN">ADMIN</SelectItem>
-                                  <SelectItem value="MEMBER">MEMBER</SelectItem>
-                                </SelectContent>
-                              </Select>
+                            <div className="min-w-0 flex-1 truncate text-sm">{member.email}</div>
+                            <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                              {member.role === TeamRole.OWNER ? (
+                                <span className="text-muted-foreground flex h-8 items-center px-2 text-sm">
+                                  Owner
+                                </span>
+                              ) : (
+                                <Select
+                                  value={member.role}
+                                  items={MEMBER_ROLE_SELECT_ITEMS}
+                                  onValueChange={(value) =>
+                                    updateMemberRole(member.userId, value as TeamRole)
+                                  }
+                                  disabled={pending || !canUpdateMemberRoles}
+                                >
+                                  <SelectTrigger className="min-w-0 w-full sm:w-36">
+                                    <SelectValue placeholder="Role" />
+                                  </SelectTrigger>
+                                  <SelectContent
+                                    align="end"
+                                    alignItemWithTrigger={false}
+                                    className="max-h-72"
+                                  >
+                                    {MEMBER_ROLE_SELECT_ITEMS.map((option) => (
+                                      <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                        label={option.label}
+                                      >
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              )}
                               <Button
                                 type="button"
                                 variant="ghost"

--- a/components/schedule/holiday-country-section.tsx
+++ b/components/schedule/holiday-country-section.tsx
@@ -32,14 +32,15 @@ export function HolidayCountrySection({ value, onChange }: Props) {
         <Label htmlFor="holiday-country">Country calendar</Label>
         <Select
           value={value}
+          items={OPTIONS}
           onValueChange={(v) => onChange(v as HolidayCountry)}
         >
-          <SelectTrigger id="holiday-country" className="w-full max-w-sm">
-            <SelectValue />
+          <SelectTrigger id="holiday-country" className="w-full min-w-0 max-w-sm">
+            <SelectValue placeholder="Country calendar" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent align="start" alignItemWithTrigger={false} className="max-h-72">
             {OPTIONS.map((o) => (
-              <SelectItem key={o.value} value={o.value}>
+              <SelectItem key={o.value} value={o.value} label={o.label}>
                 {o.label}
               </SelectItem>
             ))}

--- a/components/schedule/report-dashboard.tsx
+++ b/components/schedule/report-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import {
   Card,
@@ -37,7 +37,20 @@ type Props = {
 
 const ALL_VALUE = "all";
 
-export function ReportDashboard({
+function reportScopeKey(
+  report: PersonReport[],
+  rangeStart: string,
+  rangeEnd: string,
+): string {
+  return `${rangeStart}|${rangeEnd}|${report
+    .map(
+      (r) =>
+        `${r.memberId}:${r.weekdayDays}:${r.weekendHolidayDays}:${r.totalHours}`,
+    )
+    .join(";")}`;
+}
+
+function ReportDashboardInner({
   report,
   assignments,
   members,
@@ -53,10 +66,6 @@ export function ReportDashboard({
   const showMonthFilter = monthOptions.length > 1;
 
   const [monthFilter, setMonthFilter] = useState<string>(ALL_VALUE);
-
-  useEffect(() => {
-    setMonthFilter(ALL_VALUE);
-  }, [report, rangeStart, rangeEnd]);
 
   const displayReport = useMemo(() => {
     if (!showMonthFilter || monthFilter === ALL_VALUE) return report;
@@ -147,4 +156,12 @@ export function ReportDashboard({
       </CardContent>
     </Card>
   );
+}
+
+export function ReportDashboard(props: Props) {
+  const scopeKey = useMemo(
+    () => reportScopeKey(props.report, props.rangeStart, props.rangeEnd),
+    [props.report, props.rangeStart, props.rangeEnd],
+  );
+  return <ReportDashboardInner key={scopeKey} {...props} />;
 }

--- a/components/theme-selector.tsx
+++ b/components/theme-selector.tsx
@@ -2,7 +2,7 @@
 
 import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 import { Label } from "@/components/ui/label";
 import {
@@ -19,13 +19,17 @@ const OPTIONS = [
   { value: "system", label: "System", Icon: Monitor },
 ] as const;
 
+function useIsClient() {
+  return useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+}
+
 export function ThemeSelector() {
   const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const mounted = useIsClient();
 
   const current = theme ?? "system";
   const active = useMemo(


### PR DESCRIPTION
## Summary

Follow-up after the team management merge: polish Base UI selects (explicit `items` so triggers show names, not ids or raw codes), adjust team / holiday / role `SelectContent` alignment, improve member row layout (Owner as static label), and clear `react-hooks/set-state-in-effect` lint on the home page, report month filter, and theme selector.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual: `/` holiday country select; `/teams` team picker and member role; theme appearance

Related: follow-up to PR #39 (SCA0011 team UI).
