### PR TITLE
SCA0012: Persist schedule drafts with fewer than two members

### DIFF
--- a/lib/schedule/draft-storage.ts
+++ b/lib/schedule/draft-storage.ts
@@ -8,7 +8,7 @@ const scheduleDraftSchema = z.object({
   startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   holidayCountry: holidayCountrySchema,
-  members: z.array(scheduleMemberSchema).min(2),
+  members: z.array(scheduleMemberSchema),
   colorblindMode: z.boolean().default(false),
 });
 

--- a/tests/draft-storage.test.ts
+++ b/tests/draft-storage.test.ts
@@ -59,6 +59,46 @@ describe("schedule draft local persistence", () => {
     });
   });
 
+  it("saves and restores a one-member draft", () => {
+    installLocalStorageMock();
+
+    saveScheduleDraft({
+      startDate: "2026-04-01",
+      endDate: "2026-04-15",
+      holidayCountry: "US",
+      members: [{ id: "solo", name: "Jordan", unavailableDates: [] }],
+      colorblindMode: false,
+    });
+
+    expect(loadScheduleDraft()).toEqual({
+      startDate: "2026-04-01",
+      endDate: "2026-04-15",
+      holidayCountry: "US",
+      members: [{ id: "solo", name: "Jordan", unavailableDates: [] }],
+      colorblindMode: false,
+    });
+  });
+
+  it("saves and restores an empty-member draft", () => {
+    installLocalStorageMock();
+
+    saveScheduleDraft({
+      startDate: "2026-05-01",
+      endDate: "2026-05-07",
+      holidayCountry: "PT",
+      members: [],
+      colorblindMode: false,
+    });
+
+    expect(loadScheduleDraft()).toEqual({
+      startDate: "2026-05-01",
+      endDate: "2026-05-07",
+      holidayCountry: "PT",
+      members: [],
+      colorblindMode: false,
+    });
+  });
+
   it("restores null when persisted data is invalid", () => {
     const localStorage = installLocalStorageMock();
     localStorage.setItem(


### PR DESCRIPTION
## Summary

- Relaxed the schedule draft Zod schema so persisted \members\ may include **zero or one** valid rows; \loadScheduleDraft()\ no longer returns \
ull\ for those shapes after refresh.
- **Vitest** covers save → load round-trips for **one named member** and an **empty** roster.

\scheduleInputSchema\ / Calculate behavior is unchanged: the client still requires a full valid roster before running the server action.

Closes #32

Made with [Cursor](https://cursor.com)