### PR TITLE
feat(scheduler): signed-out tease for saved roster load (SCA0014)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { ExportCsvButton } from "@/components/schedule/export-csv-button";
 import { HolidayCountrySection } from "@/components/schedule/holiday-country-section";
 import { ReportDashboard } from "@/components/schedule/report-dashboard";
 import { ScheduleCalendar } from "@/components/schedule/schedule-calendar";
+import { TeamRosterLoadTease } from "@/components/schedule/team-roster-load-tease";
 import { TeamSection, type TeamMemberForm } from "@/components/schedule/team-section";
 import { ThemeSelector } from "@/components/theme-selector";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -202,6 +203,8 @@ export default function Home() {
             onChange={setHolidayCountry}
           />
         </div>
+
+        <TeamRosterLoadTease />
 
         <TeamSection
           members={members}

--- a/components/schedule/team-roster-load-tease.tsx
+++ b/components/schedule/team-roster-load-tease.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Signed-out prompt for loading a roster saved on the server into the calculator.
+ * Does not call team APIs; copy stays generic (no team-identifying data).
+ */
+export function TeamRosterLoadTease() {
+  const { status } = useSession();
+
+  if (status === "loading" || status === "authenticated") {
+    return null;
+  }
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle>Load a saved roster</CardTitle>
+        <CardDescription>
+          Sign in to load a roster you previously saved with your account. Nothing is fetched
+          from the server until you are signed in and choose to load it.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        <Link href="/login" className={buttonVariants({ variant: "default" })}>
+          Log in
+        </Link>
+        <Link href="/register" className={buttonVariants({ variant: "outline" })}>
+          Create account
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
﻿## Summary

Adds a small card on the home scheduler when the session is unauthenticated: explains that loading a saved roster from the server requires signing in, with Log in and Create account links matching existing account affordances. While the session is loading or the user is signed in, the strip is hidden so we do not flash the wrong state.

No team-list or roster server actions are invoked from this UI path.

## Acceptance (issue #34)

- Unauthenticated users see tease copy and a sign-in affordance consistent with the design system (Card plus button link styling, same pattern as AccountCard).
- No team list fetch runs for unauthenticated sessions (component only uses useSession; no listTeamsAction or similar).
- No organizational or team-identifying data in the tease (generic wording only).

Parent PRD: #31

Fixes #34
