### PR TITLE
feat(scheduler): load team roster into calculator (SCA0016)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,15 @@ function newMember(): TeamMemberForm {
   return { id: crypto.randomUUID(), name: "", unavailableDates: [] };
 }
 
+/** Team UI expects at least two rows (add/remove rules, calculate gate). Pad after server import when roster is empty or solo. */
+function withMinimumMemberRows(imported: TeamMemberForm[], minimum = 2): TeamMemberForm[] {
+  const next = [...imported];
+  while (next.length < minimum) {
+    next.push(newMember());
+  }
+  return next;
+}
+
 /** Stable ids for the first two rows so SSR and the client match (avoids hydration errors from random UUIDs in useState). */
 const initialMembers = (): TeamMemberForm[] => [
   { id: "member-initial-0", name: "", unavailableDates: [] },
@@ -175,7 +184,7 @@ export default function Home() {
   }, []);
 
   const handleRosterImported = useCallback((imported: TeamMemberForm[]) => {
-    setMembers(imported);
+    setMembers(withMinimumMemberRows(imported));
     setResult(null);
   }, []);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -174,6 +174,11 @@ export default function Home() {
     );
   }, []);
 
+  const handleRosterImported = useCallback((imported: TeamMemberForm[]) => {
+    setMembers(imported);
+    setResult(null);
+  }, []);
+
   return (
     <div className="bg-background min-h-full">
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10 md:px-6">
@@ -204,7 +209,7 @@ export default function Home() {
           />
         </div>
 
-        <TeamRosterLoadPanel />
+        <TeamRosterLoadPanel onRosterImported={handleRosterImported} />
 
         <TeamSection
           members={members}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -183,10 +183,23 @@ export default function Home() {
     );
   }, []);
 
-  const handleRosterImported = useCallback((imported: TeamMemberForm[]) => {
-    setMembers(withMinimumMemberRows(imported));
-    setResult(null);
-  }, []);
+  const handleRosterImported = useCallback(
+    (imported: TeamMemberForm[]) => {
+      const padded = withMinimumMemberRows(imported);
+      setMembers(padded);
+      setResult(null);
+      // Persist immediately so focus/pageshow draft sync cannot overwrite with stale localStorage
+      // before the autosave effect runs (avoids blank names right after import).
+      saveScheduleDraft({
+        startDate,
+        endDate,
+        holidayCountry,
+        members: padded,
+        colorblindMode,
+      });
+    },
+    [colorblindMode, endDate, holidayCountry, startDate],
+  );
 
   return (
     <div className="bg-background min-h-full">

--- a/components/schedule/team-roster-load-panel.tsx
+++ b/components/schedule/team-roster-load-panel.tsx
@@ -204,6 +204,8 @@ export function TeamRosterLoadPanel({ onRosterImported }: TeamRosterLoadPanelPro
         <CardDescription>
           Teams you belong to, sorted A–Z. Load replaces everyone in the member list below with the
           latest roster saved for that team (use again on the same team to refresh from the server).
+          If the saved roster has no one or only one person, blank rows are added so the form stays
+          usable until you have at least two names.
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">

--- a/components/schedule/team-roster-load-panel.tsx
+++ b/components/schedule/team-roster-load-panel.tsx
@@ -203,9 +203,10 @@ export function TeamRosterLoadPanel({ onRosterImported }: TeamRosterLoadPanelPro
         <CardTitle>Load a saved roster</CardTitle>
         <CardDescription>
           Teams you belong to, sorted A–Z. Load replaces everyone in the member list below with the
-          latest roster saved for that team (use again on the same team to refresh from the server).
-          If the saved roster has no one or only one person, blank rows are added so the form stays
-          usable until you have at least two names.
+          latest saved roster for that team, or—if nothing was saved yet—with one row per teammate
+          (display name, otherwise the part of their email before @). Use Load again on the same team
+          to refresh from the server. If you still have fewer than two people, blank rows are added
+          so you can finish the list.
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">

--- a/components/schedule/team-roster-load-panel.tsx
+++ b/components/schedule/team-roster-load-panel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 
-import { listTeamsAction } from "@/app/actions/team";
+import { listTeamsAction, loadTeamMembersAction } from "@/app/actions/team";
+import type { TeamMemberForm } from "@/components/schedule/team-section";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -18,6 +19,11 @@ import {
 } from "@/components/ui/select";
 import type { TeamSummary } from "@/lib/team/service";
 
+export type TeamRosterLoadPanelProps = {
+  /** Replaces calculator members and should clear schedule results in the parent. */
+  onRosterImported: (members: TeamMemberForm[]) => void;
+};
+
 function sortTeamsByName(teams: TeamSummary[]): TeamSummary[] {
   return [...teams].sort((a, b) =>
     a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
@@ -26,15 +32,18 @@ function sortTeamsByName(teams: TeamSummary[]): TeamSummary[] {
 
 /**
  * Home-page strip for loading a server roster into the calculator.
- * Signed-out: generic tease only (no team APIs). Signed-in: team list UI; roster replace is disabled until a follow-up issue.
+ * Signed-out: generic tease only (no team APIs). Signed-in: team list and roster import into the parent form.
  */
-export function TeamRosterLoadPanel() {
+export function TeamRosterLoadPanel({ onRosterImported }: TeamRosterLoadPanelProps) {
   const { data: session, status } = useSession();
   const sessionUserId = session?.user?.id;
   const [teams, setTeams] = useState<TeamSummary[]>([]);
   const [teamsError, setTeamsError] = useState<string | null>(null);
   const [teamsReady, setTeamsReady] = useState(false);
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+  const [rosterLoadError, setRosterLoadError] = useState<string | null>(null);
+  const [rosterPending, setRosterPending] = useState(false);
+  const rosterLoadLockRef = useRef(false);
 
   useEffect(() => {
     if (status !== "authenticated") {
@@ -83,7 +92,35 @@ export function TeamRosterLoadPanel() {
 
   const onTeamChange = useCallback((value: string) => {
     setSelectedTeamId(value);
+    setRosterLoadError(null);
   }, []);
+
+  const onLoadRoster = useCallback(() => {
+    if (!selectedTeamId || rosterLoadLockRef.current) return;
+
+    rosterLoadLockRef.current = true;
+    setRosterLoadError(null);
+    setRosterPending(true);
+    void (async () => {
+      try {
+        const response = await loadTeamMembersAction(selectedTeamId);
+        if (!response.ok) {
+          setRosterLoadError(response.error);
+          return;
+        }
+        onRosterImported(
+          response.data.members.map((m) => ({
+            id: m.id,
+            name: m.name,
+            unavailableDates: [...m.unavailableDates],
+          })),
+        );
+      } finally {
+        rosterLoadLockRef.current = false;
+        setRosterPending(false);
+      }
+    })();
+  }, [onRosterImported, selectedTeamId]);
 
   if (status === "loading") {
     return null;
@@ -165,26 +202,48 @@ export function TeamRosterLoadPanel() {
       <CardHeader>
         <CardTitle>Load a saved roster</CardTitle>
         <CardDescription>
-          Teams you belong to, sorted A–Z. Loading saved members from the server into this form is
-          not available in this release yet—the action below stays disabled until then.
+          Teams you belong to, sorted A–Z. Load replaces everyone in the member list below with the
+          latest roster saved for that team (use again on the same team to refresh from the server).
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-        <Select value={selectedTeamId ?? ""} items={teamSelectItems} onValueChange={onTeamChange}>
-          <SelectTrigger className="w-full min-w-0 sm:w-80" size="sm" aria-label="Team for roster load">
-            <SelectValue placeholder="Select a team" />
-          </SelectTrigger>
-          <SelectContent align="start" alignItemWithTrigger={false} className="max-h-72">
-            {teams.map((team) => (
-              <SelectItem key={team.id} value={team.id} label={team.name}>
-                {team.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button type="button" disabled title="Roster import is not enabled in this release yet.">
-          Load team roster
-        </Button>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+          <Select
+            value={selectedTeamId ?? ""}
+            items={teamSelectItems}
+            onValueChange={onTeamChange}
+            disabled={rosterPending}
+          >
+            <SelectTrigger
+              className="w-full min-w-0 sm:w-80"
+              size="sm"
+              aria-label="Team for roster load"
+            >
+              <SelectValue placeholder="Select a team" />
+            </SelectTrigger>
+            <SelectContent align="start" alignItemWithTrigger={false} className="max-h-72">
+              {teams.map((team) => (
+                <SelectItem key={team.id} value={team.id} label={team.name}>
+                  {team.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            type="button"
+            disabled={!selectedTeamId || rosterPending}
+            onClick={onLoadRoster}
+          >
+            {rosterPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+            Load team roster
+          </Button>
+        </div>
+        {rosterLoadError ? (
+          <Alert variant="destructive">
+            <AlertTitle>Could not load roster</AlertTitle>
+            <AlertDescription>{rosterLoadError}</AlertDescription>
+          </Alert>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/lib/schedule/draft-storage.ts
+++ b/lib/schedule/draft-storage.ts
@@ -1,14 +1,21 @@
 import { z } from "zod";
 
-import { holidayCountrySchema, scheduleMemberSchema } from "./types";
+import { holidayCountrySchema } from "./types";
 
 const DRAFT_STORAGE_KEY = "scalify:schedule-draft:v1";
+
+/** Draft members allow empty names (WIP rows); calculate still uses `scheduleInputSchema` on the server. */
+const draftMemberSchema = z.object({
+  id: z.string().min(1),
+  name: z.string(),
+  unavailableDates: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)),
+});
 
 const scheduleDraftSchema = z.object({
   startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   holidayCountry: holidayCountrySchema,
-  members: z.array(scheduleMemberSchema),
+  members: z.array(draftMemberSchema),
   colorblindMode: z.boolean().default(false),
 });
 

--- a/lib/team/service.ts
+++ b/lib/team/service.ts
@@ -233,6 +233,18 @@ export async function saveTeamMembersForCurrentUser(
   };
 }
 
+function scheduleMemberNameFromUser(user: {
+  name: string | null;
+  email: string;
+}): string {
+  const trimmedName = user.name?.trim();
+  if (trimmedName) return trimmedName;
+  const email = user.email.trim();
+  const at = email.indexOf("@");
+  const local = at > 0 ? email.slice(0, at) : email;
+  return local.length > 0 ? local : "Member";
+}
+
 export async function loadTeamMembersForCurrentUser(
   teamId: string,
 ): Promise<{ teamId: string; members: ScheduleMember[] }> {
@@ -246,7 +258,25 @@ export async function loadTeamMembersForCurrentUser(
     select: { members: true },
   });
 
-  const members = z.array(scheduleMemberSchema).parse(roster?.members ?? []);
+  let members = z.array(scheduleMemberSchema).parse(roster?.members ?? []);
+
+  if (members.length === 0) {
+    const memberships = await prisma.teamMembership.findMany({
+      where: { teamId: parsedTeamId },
+      select: {
+        userId: true,
+        user: { select: { name: true, email: true } },
+      },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+    });
+
+    members = memberships.map((m) => ({
+      id: m.userId,
+      name: scheduleMemberNameFromUser(m.user),
+      unavailableDates: [],
+    }));
+  }
+
   return {
     teamId: parsedTeamId,
     members,

--- a/tests/team-service.integration.test.ts
+++ b/tests/team-service.integration.test.ts
@@ -248,15 +248,36 @@ describe("team service integration behaviors", () => {
     expect(result.members).toHaveLength(2);
   });
 
-  it("returns empty members when a team has no saved roster yet", async () => {
+  it("returns membership-backed roster rows when no saved roster JSON exists yet", async () => {
     authMock.mockResolvedValue({
       user: { id: "user_1" },
     });
     prismaMock.teamMembership.findUnique.mockResolvedValue({ role: "OWNER" });
     prismaMock.teamRoster.findUnique.mockResolvedValue(null);
+    prismaMock.teamMembership.findMany.mockResolvedValue([
+      {
+        userId: "user_1",
+        user: { name: "Alice Owner", email: "alice@example.com" },
+      },
+      {
+        userId: "user_2",
+        user: { name: null, email: "bob@example.com" },
+      },
+    ]);
 
     const result = await loadTeamMembersForCurrentUser("team_1");
-    expect(result.members).toEqual([]);
+    expect(result.members).toEqual([
+      {
+        id: "user_1",
+        name: "Alice Owner",
+        unavailableDates: [],
+      },
+      {
+        id: "user_2",
+        name: "bob",
+        unavailableDates: [],
+      },
+    ]);
   });
 
   it("denies roster access for non-members", async () => {


### PR DESCRIPTION
## Summary

Wires **Load team roster** on the home scheduler to `loadTeamMembersAction` for the selected team. On success, the parent replaces calculator member rows with the server payload (preserving member ids and cloning unavailable dates) and clears schedule results. Failures show an alert in the load panel only (**Could not load roster**) so they stay separate from calculate errors; members are not changed.

While a load is in flight, the team select and load button are disabled, and a ref lock blocks a second concurrent request so overlapping calls cannot apply out-of-order responses.

Re-loading the same team runs a fresh server fetch each time.

## Acceptance (issue #36)

- Successful load replaces members and clears the schedule result block.
- Failed load leaves members unchanged and shows roster-specific error copy.
- Same team + Load again re-fetches from the server.
- Overlapping loads prevented (disabled UI + in-flight lock).

Parent PRD: #31

Fixes #36
