### PR TITLE
feat(schedule): member snapshot stack for import undo (SCA0017)

### DIFF
--- a/lib/schedule/member-snapshot-stack.ts
+++ b/lib/schedule/member-snapshot-stack.ts
@@ -1,0 +1,51 @@
+/**
+ * In-memory stack of member-array snapshots for roster import undo (no React).
+ * Each snapshot is deep-cloned on push and on pop so callers can mutate results safely.
+ */
+
+export const DEFAULT_MEMBER_SNAPSHOT_MAX_DEPTH = 10;
+
+function deepCloneSnapshot<T>(members: readonly T[]): T[] {
+  return structuredClone(members) as T[];
+}
+
+/**
+ * Push a snapshot of `membersBeforeReplace` (typically the current roster immediately before import).
+ * When depth would exceed `maxDepth`, the oldest snapshots are dropped.
+ */
+export function pushMemberSnapshot<T>(
+  stack: readonly T[][],
+  membersBeforeReplace: readonly T[],
+  maxDepth: number = DEFAULT_MEMBER_SNAPSHOT_MAX_DEPTH,
+): T[][] {
+  const snapshot = deepCloneSnapshot(membersBeforeReplace);
+  const extended = [...stack, snapshot];
+  if (extended.length > maxDepth) {
+    return extended.slice(-maxDepth);
+  }
+  return extended;
+}
+
+/**
+ * Pop the newest snapshot and return a deep copy to restore as current members.
+ * If the stack is empty, returns `restored: null` and the same stack reference content (empty).
+ */
+export function popMemberSnapshot<T>(stack: readonly T[][]): {
+  stack: T[][];
+  restored: T[] | null;
+} {
+  if (stack.length === 0) {
+    return { stack: [], restored: null };
+  }
+  const top = stack[stack.length - 1]!;
+  const nextStack = stack.slice(0, -1);
+  return { stack: [...nextStack], restored: deepCloneSnapshot(top) };
+}
+
+export function clearMemberSnapshots<T>(): T[][] {
+  return [];
+}
+
+export function memberSnapshotDepth<T>(stack: readonly T[][]): number {
+  return stack.length;
+}

--- a/tests/member-snapshot-stack.test.ts
+++ b/tests/member-snapshot-stack.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clearMemberSnapshots,
+  DEFAULT_MEMBER_SNAPSHOT_MAX_DEPTH,
+  memberSnapshotDepth,
+  popMemberSnapshot,
+  pushMemberSnapshot,
+} from "@/lib/schedule/member-snapshot-stack";
+
+type Row = { id: string; name: string; unavailableDates: string[] };
+
+function row(id: string, name: string): Row {
+  return { id, name, unavailableDates: [] };
+}
+
+describe("memberSnapshotStack", () => {
+  it("pushes and pops in LIFO order", () => {
+    let stack = clearMemberSnapshots<Row>();
+    stack = pushMemberSnapshot(stack, [row("1", "A"), row("2", "B")]);
+    stack = pushMemberSnapshot(stack, [row("1", "X")]);
+    expect(memberSnapshotDepth(stack)).toBe(2);
+
+    const first = popMemberSnapshot(stack);
+    expect(first.restored).toEqual([row("1", "X")]);
+    stack = first.stack;
+
+    const second = popMemberSnapshot(stack);
+    expect(second.restored).toEqual([
+      { id: "1", name: "A", unavailableDates: [] },
+      { id: "2", name: "B", unavailableDates: [] },
+    ]);
+    stack = second.stack;
+
+    const third = popMemberSnapshot(stack);
+    expect(third.restored).toBeNull();
+    expect(third.stack).toEqual([]);
+  });
+
+  it("drops oldest snapshots when depth exceeds maxDepth", () => {
+    const max = 3;
+    let stack = clearMemberSnapshots<Row>();
+    for (let i = 0; i < 5; i += 1) {
+      stack = pushMemberSnapshot(stack, [row("a", `snap-${i}`)], max);
+    }
+    expect(memberSnapshotDepth(stack)).toBe(max);
+
+    // Oldest dropped: stack holds snap-2, snap-3, snap-4
+    let popped = popMemberSnapshot(stack);
+    expect(popped.restored).toEqual([row("a", "snap-4")]);
+    stack = popped.stack;
+
+    popped = popMemberSnapshot(stack);
+    expect(popped.restored).toEqual([row("a", "snap-3")]);
+    stack = popped.stack;
+
+    popped = popMemberSnapshot(stack);
+    expect(popped.restored).toEqual([row("a", "snap-2")]);
+    stack = popped.stack;
+
+    expect(popMemberSnapshot(stack).restored).toBeNull();
+  });
+
+  it("uses DEFAULT_MEMBER_SNAPSHOT_MAX_DEPTH when maxDepth omitted", () => {
+    let stack = clearMemberSnapshots<Row[]>();
+    for (let i = 0; i < DEFAULT_MEMBER_SNAPSHOT_MAX_DEPTH + 3; i += 1) {
+      stack = pushMemberSnapshot(stack, [row("x", `n${i}`)]);
+    }
+    expect(memberSnapshotDepth(stack)).toBe(DEFAULT_MEMBER_SNAPSHOT_MAX_DEPTH);
+  });
+
+  it("pop on empty stack is a no-op", () => {
+    const stack = clearMemberSnapshots<Row>();
+    const out = popMemberSnapshot(stack);
+    expect(out.restored).toBeNull();
+    expect(out.stack).toEqual([]);
+  });
+
+  it("isolates snapshots from later in-place edits to the source array", () => {
+    const live: Row[] = [row("1", "A")];
+    const stack = pushMemberSnapshot(clearMemberSnapshots<Row>(), live);
+    live[0] = { ...live[0], name: "Mutated" };
+
+    const popped = popMemberSnapshot(stack);
+    expect(popped.restored).toEqual([row("1", "A")]);
+  });
+
+  it("isolates restored members from the stack (mutate restore does not affect next pop)", () => {
+    let stack = clearMemberSnapshots<Row>();
+    stack = pushMemberSnapshot(stack, [row("1", "A")]);
+    stack = pushMemberSnapshot(stack, [row("1", "B")]);
+
+    const outer = popMemberSnapshot(stack);
+    expect(outer.restored?.[0].name).toBe("B");
+    outer.restored![0].name = "Hacked";
+    stack = outer.stack;
+
+    const inner = popMemberSnapshot(stack);
+    expect(inner.restored?.[0].name).toBe("A");
+  });
+
+  it("deep-copies unavailableDates arrays per row", () => {
+    const live: Row[] = [{ id: "1", name: "A", unavailableDates: ["2026-05-01"] }];
+    const stack = pushMemberSnapshot(clearMemberSnapshots<Row>(), live);
+    live[0].unavailableDates.push("2026-05-02");
+
+    const popped = popMemberSnapshot(stack);
+    expect(popped.restored).toEqual([
+      { id: "1", name: "A", unavailableDates: ["2026-05-01"] },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `lib/schedule/member-snapshot-stack.ts`: immutable-style helpers to push a deep-cloned member-array snapshot before a destructive replace, pop the newest snapshot (or no-op when empty), trim to a configurable max depth by dropping the oldest entries (default 10), plus `clearMemberSnapshots` and `memberSnapshotDepth`.

Snapshots use `structuredClone` so nested arrays (e.g. `unavailableDates`) and later edits to live rows do not corrupt stack history.

No scheduler UI changes in this slice (wire-up is #38).

## Acceptance (issue #37)

- Vitest covers LIFO push/pop, max-depth cap, safe pop on empty stack, and isolation from in-place mutations.
- Snapshots are deep-copied on push and on pop.
- Module is ready to integrate with the home-page import flow in a follow-up.

Parent PRD: #31

Fixes #37
