### PR TITLE
feat(scheduler): import undo stack and reset integration (SCA0018)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,12 @@ import {
   loadScheduleDraft,
   saveScheduleDraft,
 } from "@/lib/schedule/draft-storage";
+import {
+  clearMemberSnapshots,
+  memberSnapshotDepth,
+  popMemberSnapshot,
+  pushMemberSnapshot,
+} from "@/lib/schedule/member-snapshot-stack";
 import type { HolidayCountry, ScheduleResult } from "@/lib/schedule/types";
 import { scheduleInputSchema } from "@/lib/schedule/types";
 
@@ -66,8 +72,12 @@ export default function Home() {
   const [result, setResult] = useState<ScheduleResult | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [importSnapshotStack, setImportSnapshotStack] = useState<TeamMemberForm[][]>(() =>
+    clearMemberSnapshots<TeamMemberForm>(),
+  );
 
   const hydrateFromDraft = useCallback(() => {
+    setImportSnapshotStack(clearMemberSnapshots<TeamMemberForm>());
     const draft = loadScheduleDraft();
     if (!draft) {
       setHasHydratedDraft(true);
@@ -154,6 +164,7 @@ export default function Home() {
   const resetDraft = useCallback(() => {
     const defaults = defaultRange();
     clearScheduleDraft();
+    setImportSnapshotStack(clearMemberSnapshots<TeamMemberForm>());
     setStartDate(defaults.start);
     setEndDate(defaults.end);
     setHolidayCountry("US");
@@ -185,6 +196,7 @@ export default function Home() {
 
   const handleRosterImported = useCallback(
     (imported: TeamMemberForm[]) => {
+      setImportSnapshotStack((prev) => pushMemberSnapshot(prev, members));
       const padded = withMinimumMemberRows(imported);
       setMembers(padded);
       setResult(null);
@@ -198,8 +210,26 @@ export default function Home() {
         colorblindMode,
       });
     },
-    [colorblindMode, endDate, holidayCountry, startDate],
+    [colorblindMode, endDate, holidayCountry, members, startDate],
   );
+
+  const handleImportUndo = useCallback(() => {
+    setImportSnapshotStack((prevStack) => {
+      const { stack, restored } = popMemberSnapshot(prevStack);
+      if (restored !== null) {
+        setMembers(restored);
+        setResult(null);
+        saveScheduleDraft({
+          startDate,
+          endDate,
+          holidayCountry,
+          members: restored,
+          colorblindMode,
+        });
+      }
+      return stack;
+    });
+  }, [colorblindMode, endDate, holidayCountry, startDate]);
 
   return (
     <div className="bg-background min-h-full">
@@ -231,7 +261,11 @@ export default function Home() {
           />
         </div>
 
-        <TeamRosterLoadPanel onRosterImported={handleRosterImported} />
+        <TeamRosterLoadPanel
+          onRosterImported={handleRosterImported}
+          importUndoDepth={memberSnapshotDepth(importSnapshotStack)}
+          onImportUndo={handleImportUndo}
+        />
 
         <TeamSection
           members={members}

--- a/components/schedule/team-roster-load-panel.tsx
+++ b/components/schedule/team-roster-load-panel.tsx
@@ -22,6 +22,10 @@ import type { TeamSummary } from "@/lib/team/service";
 export type TeamRosterLoadPanelProps = {
   /** Replaces calculator members and should clear schedule results in the parent. */
   onRosterImported: (members: TeamMemberForm[]) => void;
+  /** Number of import steps that can be undone; when 0 the Undo control is hidden. */
+  importUndoDepth: number;
+  /** Restores the previous member rows and clears schedule results in the parent. */
+  onImportUndo: () => void;
 };
 
 function sortTeamsByName(teams: TeamSummary[]): TeamSummary[] {
@@ -34,7 +38,11 @@ function sortTeamsByName(teams: TeamSummary[]): TeamSummary[] {
  * Home-page strip for loading a server roster into the calculator.
  * Signed-out: generic tease only (no team APIs). Signed-in: team list and roster import into the parent form.
  */
-export function TeamRosterLoadPanel({ onRosterImported }: TeamRosterLoadPanelProps) {
+export function TeamRosterLoadPanel({
+  onRosterImported,
+  importUndoDepth,
+  onImportUndo,
+}: TeamRosterLoadPanelProps) {
   const { data: session, status } = useSession();
   const sessionUserId = session?.user?.id;
   const [teams, setTeams] = useState<TeamSummary[]>([]);
@@ -206,7 +214,8 @@ export function TeamRosterLoadPanel({ onRosterImported }: TeamRosterLoadPanelPro
           latest saved roster for that team, or—if nothing was saved yet—with one row per teammate
           (display name, otherwise the part of their email before @). Use Load again on the same team
           to refresh from the server. If you still have fewer than two people, blank rows are added
-          so you can finish the list.
+          so you can finish the list. After a successful load, use Undo roster load to step back
+          through prior member lists (up to ten imports).
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
@@ -240,6 +249,17 @@ export function TeamRosterLoadPanel({ onRosterImported }: TeamRosterLoadPanelPro
             {rosterPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
             Load team roster
           </Button>
+          {importUndoDepth > 0 ? (
+            <Button
+              type="button"
+              variant="outline"
+              disabled={rosterPending}
+              onClick={onImportUndo}
+              aria-label={`Undo roster load (${importUndoDepth} step${importUndoDepth === 1 ? "" : "s"} available)`}
+            >
+              Undo roster load
+            </Button>
+          ) : null}
         </div>
         {rosterLoadError ? (
           <Alert variant="destructive">


### PR DESCRIPTION
## Summary

Wires `lib/schedule/member-snapshot-stack` into the home scheduler:

- On each **successful** roster import, the **current** member rows are **pushed** onto the stack, then the imported roster replaces them (same `DEFAULT_MEMBER_SNAPSHOT_MAX_DEPTH` / cap as the library).
- **Undo roster load** appears in the load panel when the stack is non-empty; it **pops**, restores members, clears schedule **results**, and re-saves the draft immediately (same pattern as import).
- **Reset draft** clears the import snapshot stack along with dates, members, theme toggle, and errors.
- **Draft hydrate** (initial load and focus/pageshow sync) clears the stack so undo history does not survive a restored draft session.

## Acceptance (issue #38)

- Successful import pushes a snapshot; Undo restores the previous member rows.
- Each Undo clears schedule results.
- Reset draft clears import undo history.
- Stack depth cap is enforced via `pushMemberSnapshot` default max depth.

Parent PRD: #31

Fixes #38
