### PR TITLE
feat(auth): gate /teams and /account with login callback (SCA0019)

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+import { AccountCard } from "@/components/auth/account-card";
+import { ThemeSelector } from "@/components/theme-selector";
+
+export default function AccountPage() {
+  return (
+    <div className="bg-background min-h-full">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10 md:px-6">
+        <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <h1 className="font-heading text-3xl font-semibold tracking-tight">Account</h1>
+            <p className="text-muted-foreground text-sm md:text-base">
+              Your sign-in and profile settings live here.
+            </p>
+          </div>
+          <ThemeSelector />
+        </header>
+
+        <AccountCard />
+
+        <div className="flex flex-wrap gap-4 text-sm">
+          <Link href="/teams" className="text-primary underline-offset-4 hover:underline">
+            Teams
+          </Link>
+          <Link href="/" className="text-primary underline-offset-4 hover:underline">
+            Back to scheduler
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,20 +1,83 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useTransition } from "react";
+import { Suspense, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
 import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { safePostLoginPath } from "@/lib/auth/safe-callback-url";
 
-export default function LoginPage() {
+function LoginForm() {
+  const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Welcome back</CardTitle>
+          <CardDescription>Use your email and password.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              const form = event.currentTarget;
+              const formData = new FormData(form);
+              startTransition(async () => {
+                const result = await signIn("credentials", {
+                  email: String(formData.get("email") ?? ""),
+                  password: String(formData.get("password") ?? ""),
+                  redirect: false,
+                });
+                if (result?.error) {
+                  setError("Invalid email or password.");
+                  return;
+                }
+                const next = safePostLoginPath(
+                  searchParams.get("callbackUrl"),
+                  window.location.origin,
+                );
+                window.location.assign(next);
+              });
+            }}
+          >
+            <div className="space-y-1">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" name="email" type="email" required />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" name="password" type="password" required />
+            </div>
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+              Log in
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Could not log in</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+    </>
+  );
+}
+
+export default function LoginPage() {
   return (
     <main className="bg-background min-h-full px-4 py-10">
       <div className="mx-auto flex w-full max-w-md flex-col gap-6">
@@ -25,55 +88,18 @@ export default function LoginPage() {
           </p>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Welcome back</CardTitle>
-            <CardDescription>Use your email and password.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form
-              className="space-y-4"
-              onSubmit={(event) => {
-                event.preventDefault();
-                setError(null);
-                const form = event.currentTarget;
-                const formData = new FormData(form);
-                startTransition(async () => {
-                  const result = await signIn("credentials", {
-                    email: String(formData.get("email") ?? ""),
-                    password: String(formData.get("password") ?? ""),
-                    redirect: false,
-                  });
-                  if (result?.error) {
-                    setError("Invalid email or password.");
-                    return;
-                  }
-                  window.location.assign("/");
-                });
-              }}
-            >
-              <div className="space-y-1">
-                <Label htmlFor="email">Email</Label>
-                <Input id="email" name="email" type="email" required />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="password">Password</Label>
-                <Input id="password" name="password" type="password" required />
-              </div>
-              <Button type="submit" className="w-full" disabled={isPending}>
-                {isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
-                Log in
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
-
-        {error ? (
-          <Alert variant="destructive">
-            <AlertTitle>Could not log in</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        ) : null}
+        <Suspense
+          fallback={
+            <Card>
+              <CardHeader>
+                <CardTitle>Welcome back</CardTitle>
+                <CardDescription>Loading…</CardDescription>
+              </CardHeader>
+            </Card>
+          }
+        >
+          <LoginForm />
+        </Suspense>
 
         <p className="text-muted-foreground text-sm">
           Need an account?{" "}

--- a/components/schedule/team-roster-load-panel.tsx
+++ b/components/schedule/team-roster-load-panel.tsx
@@ -98,7 +98,10 @@ export function TeamRosterLoadPanel({
     [teams],
   );
 
-  const onTeamChange = useCallback((value: string) => {
+  const onTeamChange = useCallback((value: string | null) => {
+    if (value == null) {
+      return;
+    }
     setSelectedTeamId(value);
     setRosterLoadError(null);
   }, []);

--- a/lib/auth/safe-callback-url.ts
+++ b/lib/auth/safe-callback-url.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolves a post-login redirect target from `callbackUrl` query param.
+ * Only same-origin paths are allowed; auth pages fall back to `/`.
+ */
+export function safePostLoginPath(
+  callbackUrl: string | null | undefined,
+  windowOrigin: string,
+): string {
+  if (!callbackUrl) {
+    return "/";
+  }
+  const trimmed = callbackUrl.trim();
+  if (!trimmed) {
+    return "/";
+  }
+  try {
+    const resolved = new URL(trimmed, windowOrigin);
+    if (resolved.origin !== new URL(windowOrigin).origin) {
+      return "/";
+    }
+    const path = `${resolved.pathname}${resolved.search}${resolved.hash}`;
+    if (!path.startsWith("/") || path.startsWith("//")) {
+      return "/";
+    }
+    if (
+      path === "/login" ||
+      path.startsWith("/login?") ||
+      path === "/register" ||
+      path.startsWith("/register?")
+    ) {
+      return "/";
+    }
+    return path || "/";
+  } catch {
+    return "/";
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getToken } from "next-auth/jwt";
+
+const SIGN_IN_PATH = "/login";
+
+function isProtectedPath(pathname: string): boolean {
+  return (
+    pathname === "/teams" ||
+    pathname.startsWith("/teams/") ||
+    pathname === "/account" ||
+    pathname.startsWith("/account/")
+  );
+}
+
+export async function middleware(request: NextRequest) {
+  if (!isProtectedPath(request.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    return NextResponse.next();
+  }
+
+  const token = await getToken({ req: request, secret });
+  if (token) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = SIGN_IN_PATH;
+  const returnPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+  url.searchParams.set("callbackUrl", returnPath);
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: ["/teams", "/teams/:path*", "/account", "/account/:path*"],
+};

--- a/tests/safe-callback-url.test.ts
+++ b/tests/safe-callback-url.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { safePostLoginPath } from "@/lib/auth/safe-callback-url";
+
+const origin = "http://localhost:3000";
+
+describe("safePostLoginPath", () => {
+  it("defaults to home when callback is missing", () => {
+    expect(safePostLoginPath(null, origin)).toBe("/");
+    expect(safePostLoginPath(undefined, origin)).toBe("/");
+    expect(safePostLoginPath("  ", origin)).toBe("/");
+  });
+
+  it("allows same-origin paths", () => {
+    expect(safePostLoginPath("/teams", origin)).toBe("/teams");
+    expect(safePostLoginPath("/account", origin)).toBe("/account");
+    expect(safePostLoginPath("/teams?tab=1", origin)).toBe("/teams?tab=1");
+  });
+
+  it("resolves absolute same-origin URLs to path", () => {
+    expect(safePostLoginPath("http://localhost:3000/teams", origin)).toBe("/teams");
+  });
+
+  it("rejects other origins", () => {
+    expect(safePostLoginPath("https://evil.example/phish", origin)).toBe("/");
+    expect(safePostLoginPath("//evil.example/phish", origin)).toBe("/");
+  });
+
+  it("avoids redirect loops through auth pages", () => {
+    expect(safePostLoginPath("/login", origin)).toBe("/");
+    expect(safePostLoginPath("/login?x=1", origin)).toBe("/");
+    expect(safePostLoginPath("/register", origin)).toBe("/");
+  });
+});


### PR DESCRIPTION
## What

- **Middleware** (Edge-safe): unauthenticated visits to \/teams\ and \/account\ redirect to \/login?callbackUrl=...\ using \getToken\ from \
ext-auth/jwt\, so we do not import \uth.ts\ (and Prisma) into middleware.
- **Login**: after successful credentials sign-in, redirect to a **same-origin** path from \callbackUrl\ via \safePostLoginPath\ (blocks external URLs and avoids loops via \/login\ / \/register\).
- **\/account\**: minimal page so the route exists for the gate and for follow-up shell work (SCA0021).

## Notes

- Fixed a **Select \onValueChange\** type mismatch in \	eam-roster-load-panel.tsx\ that was failing \
ext build\ on \main\.

Closes #48

Made with [Cursor](https://cursor.com)