### PR TITLE
feat(account): avatar presign/finalize and cleanup (SCA0022)

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import Image from "next/image";
 import type { Session } from "next-auth";
 import { signOut, useSession } from "next-auth/react";
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 
 import {
   changePasswordAction,
   deleteAccountAction,
+  finalizeAvatarUploadAction,
+  presignAvatarUploadAction,
   updateEmailAction,
   updateProfileAction,
 } from "@/app/actions/account";
@@ -16,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ALLOWED_AVATAR_CONTENT_TYPES, MAX_AVATAR_BYTES } from "@/lib/storage";
 
 function FieldError({ messages }: { messages?: string[] }) {
   if (!messages?.length) return null;
@@ -33,6 +37,7 @@ function AccountSettingsForms({
   user: NonNullable<Session["user"]>;
   updateSession: NonNullable<ReturnType<typeof useSession>["update"]>;
 }) {
+  const avatarInputRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState(user.name ?? "");
   const [newEmail, setNewEmail] = useState(user.email);
   const [emailCurrentPassword, setEmailCurrentPassword] = useState("");
@@ -58,6 +63,9 @@ function AccountSettingsForms({
 
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleteFieldErrors, setDeleteFieldErrors] = useState<Record<string, string[]>>({});
+  const [avatarError, setAvatarError] = useState<string | null>(null);
+  const [avatarMessage, setAvatarMessage] = useState<string | null>(null);
+  const [pendingAvatar, startAvatar] = useTransition();
 
   const [pendingProfile, startProfile] = useTransition();
   const [pendingEmail, startEmail] = useTransition();
@@ -66,8 +74,117 @@ function AccountSettingsForms({
 
   const emailVerified = user.emailVerified;
 
+  const avatarMaxMb = (MAX_AVATAR_BYTES / (1024 * 1024)).toFixed(0);
+  const allowedAvatarAccept = ALLOWED_AVATAR_CONTENT_TYPES.join(",");
+
   return (
     <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Avatar</CardTitle>
+          <CardDescription>
+            Upload a JPG, PNG, WEBP, or GIF up to {avatarMaxMb} MB. The file uploads directly to
+            storage using a short-lived signed URL.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3">
+              <div className="bg-muted text-muted-foreground flex size-12 items-center justify-center overflow-hidden rounded-full text-xs">
+                {user.image ? (
+                  <Image
+                    src={user.image}
+                    alt="Current avatar"
+                    className="size-full object-cover"
+                    width={48}
+                    height={48}
+                    unoptimized
+                  />
+                ) : (
+                  "None"
+                )}
+              </div>
+              <p className="text-muted-foreground text-sm">
+                {user.image ? "Current avatar image." : "No avatar uploaded yet."}
+              </p>
+            </div>
+            <Input
+              ref={avatarInputRef}
+              id="account-avatar-file"
+              type="file"
+              accept={allowedAvatarAccept}
+              disabled={pendingAvatar}
+            />
+          </div>
+          {avatarError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Could not upload avatar</AlertTitle>
+              <AlertDescription>{avatarError}</AlertDescription>
+            </Alert>
+          ) : null}
+          {avatarMessage ? (
+            <Alert>
+              <AlertTitle>Avatar updated</AlertTitle>
+              <AlertDescription>{avatarMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+          <Button
+            type="button"
+            disabled={pendingAvatar}
+            onClick={() => {
+              setAvatarError(null);
+              setAvatarMessage(null);
+              const file = avatarInputRef.current?.files?.[0];
+              if (!file) {
+                setAvatarError("Choose an image file first.");
+                return;
+              }
+              startAvatar(async () => {
+                const presign = await presignAvatarUploadAction({
+                  contentType: file.type,
+                  contentLength: file.size,
+                });
+                if (!presign.ok) {
+                  setAvatarError(presign.error);
+                  return;
+                }
+
+                const putRes = await fetch(presign.data.uploadUrl, {
+                  method: "PUT",
+                  headers: { "Content-Type": file.type },
+                  body: file,
+                });
+                if (!putRes.ok) {
+                  setAvatarError("Upload failed. Try again with a different image.");
+                  return;
+                }
+
+                const finalize = await finalizeAvatarUploadAction({
+                  objectKey: presign.data.objectKey,
+                });
+                if (!finalize.ok) {
+                  setAvatarError(finalize.error);
+                  return;
+                }
+                await updateSession({
+                  name: finalize.data.sessionUpdate.name,
+                  email: finalize.data.sessionUpdate.email,
+                  emailVerified: finalize.data.sessionUpdate.emailVerified,
+                  image: finalize.data.sessionUpdate.image,
+                });
+                if (avatarInputRef.current) {
+                  avatarInputRef.current.value = "";
+                }
+                setAvatarMessage("Your avatar was uploaded.");
+              });
+            }}
+          >
+            {pendingAvatar ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+            Upload avatar
+          </Button>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Profile</CardTitle>

--- a/app/actions/account.ts
+++ b/app/actions/account.ts
@@ -3,6 +3,7 @@
 import { ZodError } from "zod";
 
 import {
+  AccountStorageUnavailableError,
   AccountEmailConfirmMismatchError,
   AccountEmailTakenError,
   AccountNoPasswordError,
@@ -11,9 +12,12 @@ import {
   UnauthorizedAccountError,
   changePasswordForCurrentUser,
   deleteAccountForCurrentUser,
+  finalizeAvatarUploadForCurrentUser,
+  presignAvatarUploadForCurrentUser,
   updateEmailForCurrentUser,
   updateProfileForCurrentUser,
 } from "@/lib/account/service";
+import { AvatarValidationError } from "@/lib/storage";
 
 type AccountActionError = {
   ok: false;
@@ -61,6 +65,9 @@ function toAccountActionError(error: unknown): AccountActionError {
       fieldErrors: { confirmEmail: [error.message] },
     };
   }
+  if (error instanceof AvatarValidationError || error instanceof AccountStorageUnavailableError) {
+    return { ok: false, error: error.message };
+  }
   console.error(error);
   return { ok: false, error: "Something went wrong. Try again." };
 }
@@ -104,6 +111,33 @@ export async function deleteAccountAction(
   try {
     await deleteAccountForCurrentUser(raw);
     return { ok: true, data: { deleted: true } };
+  } catch (error) {
+    return toAccountActionError(error);
+  }
+}
+
+export async function presignAvatarUploadAction(raw: unknown): Promise<
+  | AccountActionSuccess<{
+      uploadUrl: string;
+      objectKey: string;
+      expiresInSeconds: number;
+    }>
+  | AccountActionError
+> {
+  try {
+    const data = await presignAvatarUploadForCurrentUser(raw);
+    return { ok: true, data };
+  } catch (error) {
+    return toAccountActionError(error);
+  }
+}
+
+export async function finalizeAvatarUploadAction(raw: unknown): Promise<
+  AccountActionSuccess<{ sessionUpdate: AccountSessionPatch }> | AccountActionError
+> {
+  try {
+    const patch = await finalizeAvatarUploadForCurrentUser(raw);
+    return { ok: true, data: { sessionUpdate: patch } };
   } catch (error) {
     return toAccountActionError(error);
   }

--- a/lib/account/service.ts
+++ b/lib/account/service.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
+import {
+  avatarObjectKeyBelongsToUser,
+  createS3ObjectStorageFromProcess,
+  isWellFormedAvatarObjectKey,
+  objectKeyFromPublicUrl,
+} from "@/lib/storage";
 
 const nameSchema = z
   .string()
@@ -35,6 +41,22 @@ const changePasswordSchema = z.object({
 const deleteAccountSchema = z.object({
   currentPassword: z.string().min(1, "Current password is required."),
   confirmEmail: z.string().trim().min(1, "Type your account email to confirm."),
+});
+
+const presignAvatarSchema = z.object({
+  contentType: z.string().trim().min(1, "Avatar content type is required."),
+  contentLength: z
+    .number()
+    .finite("Avatar size must be a number.")
+    .positive("Avatar size must be positive."),
+});
+
+const finalizeAvatarSchema = z.object({
+  objectKey: z
+    .string()
+    .trim()
+    .min(1, "Avatar object key is required.")
+    .refine((v) => isWellFormedAvatarObjectKey(v), "Avatar object key is invalid."),
 });
 
 export class UnauthorizedAccountError extends Error {
@@ -72,6 +94,13 @@ export class AccountEmailConfirmMismatchError extends Error {
   }
 }
 
+export class AccountStorageUnavailableError extends Error {
+  constructor() {
+    super("Avatar uploads are not configured right now.");
+    this.name = "AccountStorageUnavailableError";
+  }
+}
+
 async function requireUserId(): Promise<string> {
   const session = await auth();
   const id = session?.user?.id;
@@ -102,6 +131,41 @@ export type AccountSessionPatch = {
   image: string | null;
 };
 
+function toAccountSessionPatch(input: {
+  name: string | null;
+  email: string;
+  emailVerified: Date | null;
+  image: string | null;
+}): AccountSessionPatch {
+  return {
+    name: input.name,
+    email: input.email,
+    emailVerified: input.emailVerified,
+    image: input.image,
+  };
+}
+
+function tryCreateStorage() {
+  try {
+    return createS3ObjectStorageFromProcess();
+  } catch {
+    return null;
+  }
+}
+
+async function bestEffortDeleteAvatarByPublicUrl(imageUrl: string | null): Promise<void> {
+  if (!imageUrl) return;
+  const storage = tryCreateStorage();
+  if (!storage) return;
+  const objectKey = objectKeyFromPublicUrl(process.env.S3_PUBLIC_URL_BASE ?? "", imageUrl);
+  if (!objectKey || !isWellFormedAvatarObjectKey(objectKey)) return;
+  try {
+    await storage.deleteObject(objectKey);
+  } catch {
+    // Best-effort cleanup should not block account flows.
+  }
+}
+
 export async function updateProfileForCurrentUser(
   raw: unknown,
 ): Promise<AccountSessionPatch> {
@@ -118,10 +182,7 @@ export async function updateProfileForCurrentUser(
   });
 
   return {
-    name: updated.name,
-    email: updated.email,
-    emailVerified: updated.emailVerified,
-    image: updated.image,
+    ...toAccountSessionPatch(updated),
   };
 }
 
@@ -148,10 +209,7 @@ export async function updateEmailForCurrentUser(
 
   if (current.email.toLowerCase() === normalized) {
     return {
-      name: current.name,
-      email: current.email,
-      emailVerified: current.emailVerified,
-      image: current.image,
+      ...toAccountSessionPatch(current),
     };
   }
 
@@ -173,11 +231,66 @@ export async function updateEmailForCurrentUser(
   });
 
   return {
-    name: updated.name,
-    email: updated.email,
-    emailVerified: updated.emailVerified,
-    image: updated.image,
+    ...toAccountSessionPatch(updated),
   };
+}
+
+export async function presignAvatarUploadForCurrentUser(raw: unknown): Promise<{
+  uploadUrl: string;
+  objectKey: string;
+  expiresInSeconds: number;
+}> {
+  const userId = await requireUserId();
+  const parsed = presignAvatarSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+  const storage = tryCreateStorage();
+  if (!storage) {
+    throw new AccountStorageUnavailableError();
+  }
+  return storage.presignPutAvatar({
+    userId,
+    contentType: parsed.data.contentType,
+    contentLength: parsed.data.contentLength,
+  });
+}
+
+export async function finalizeAvatarUploadForCurrentUser(
+  raw: unknown,
+): Promise<AccountSessionPatch> {
+  const userId = await requireUserId();
+  const parsed = finalizeAvatarSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+  if (!avatarObjectKeyBelongsToUser(parsed.data.objectKey, userId)) {
+    throw new UnauthorizedAccountError();
+  }
+  const storage = tryCreateStorage();
+  if (!storage) {
+    throw new AccountStorageUnavailableError();
+  }
+  const newImageUrl = storage.getPublicUrlForKey(parsed.data.objectKey);
+  const current = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true, email: true, emailVerified: true, image: true },
+  });
+  if (!current) {
+    throw new UnauthorizedAccountError();
+  }
+
+  const updated = await prisma.user.update({
+    where: { id: userId },
+    data: { image: newImageUrl },
+    select: { name: true, email: true, emailVerified: true, image: true },
+  });
+
+  if (current.image && current.image !== newImageUrl) {
+    await bestEffortDeleteAvatarByPublicUrl(current.image);
+  }
+
+  return toAccountSessionPatch(updated);
 }
 
 export async function changePasswordForCurrentUser(raw: unknown): Promise<void> {
@@ -205,7 +318,7 @@ export async function deleteAccountForCurrentUser(raw: unknown): Promise<void> {
 
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { email: true },
+    select: { email: true, image: true },
   });
   if (!user) {
     throw new UnauthorizedAccountError();
@@ -218,5 +331,6 @@ export async function deleteAccountForCurrentUser(raw: unknown): Promise<void> {
     throw new AccountEmailConfirmMismatchError();
   }
 
+  await bestEffortDeleteAvatarByPublicUrl(user.image);
   await prisma.user.delete({ where: { id: userId } });
 }

--- a/lib/storage/avatar-key.ts
+++ b/lib/storage/avatar-key.ts
@@ -30,3 +30,15 @@ export function isWellFormedAvatarObjectKey(key: string): boolean {
   if (segments.length < 2) return false;
   return segments.every((s) => s.length > 0 && !s.includes(".."));
 }
+
+/**
+ * Validates ownership for keys generated as `avatars/{userId}/{objectId}`.
+ * This is enforced during finalize/delete flows to prevent cross-user writes.
+ */
+export function avatarObjectKeyBelongsToUser(
+  key: string,
+  userId: string,
+): boolean {
+  assertSafeUserId(userId);
+  return isWellFormedAvatarObjectKey(key) && key.startsWith(`${AVATAR_OBJECT_PREFIX}${userId}/`);
+}

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -24,6 +24,7 @@ export {
   normalizeAvatarContentType,
 } from "@/lib/storage/avatar-validation";
 export {
+  avatarObjectKeyBelongsToUser,
   isWellFormedAvatarObjectKey,
   makeAvatarObjectKey,
 } from "@/lib/storage/avatar-key";

--- a/tests/storage-avatar.test.ts
+++ b/tests/storage-avatar.test.ts
@@ -5,7 +5,11 @@ import {
   AvatarValidationError,
   normalizeAvatarContentType,
 } from "@/lib/storage/avatar-validation";
-import { isWellFormedAvatarObjectKey, makeAvatarObjectKey } from "@/lib/storage/avatar-key";
+import {
+  avatarObjectKeyBelongsToUser,
+  isWellFormedAvatarObjectKey,
+  makeAvatarObjectKey,
+} from "@/lib/storage/avatar-key";
 import { MAX_AVATAR_BYTES } from "@/lib/storage/constants";
 import {
   composePublicObjectUrl,
@@ -72,6 +76,19 @@ describe("isWellFormedAvatarObjectKey", () => {
     expect(isWellFormedAvatarObjectKey("other/avatars/x")).toBe(false);
     expect(isWellFormedAvatarObjectKey("avatars/../x")).toBe(false);
     expect(isWellFormedAvatarObjectKey("avatars/onlyone")).toBe(false);
+  });
+});
+
+describe("avatarObjectKeyBelongsToUser", () => {
+  it("accepts keys minted for the same user id", () => {
+    const userId = "clabcdefghijklmn";
+    const key = makeAvatarObjectKey(userId);
+    expect(avatarObjectKeyBelongsToUser(key, userId)).toBe(true);
+  });
+
+  it("rejects keys that target a different user", () => {
+    const key = "avatars/cluserone1234/fileid";
+    expect(avatarObjectKeyBelongsToUser(key, "clusertwo5678")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add account avatar server actions for short-lived presigned PUT and finalize-to-session update
- enforce avatar key ownership and best-effort deletion of previous avatar object on replace/account delete
- wire `/account` UI upload flow (presign -> PUT -> finalize) and add helper tests for key ownership validation

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [ ] Manual: run app with MinIO config, upload avatar from `/account`, confirm image refreshes
- [ ] Manual: replace avatar and verify previous object delete is best-effort

Closes #51