### PR TITLE
feat(auth): split-screen login redesign and auth hardening

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import Image from "next/image";
 import type { Session } from "next-auth";
 import { signOut, useSession } from "next-auth/react";
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 
 import {
   changePasswordAction,
   deleteAccountAction,
+  finalizeAvatarUploadAction,
+  presignAvatarUploadAction,
   updateEmailAction,
   updateProfileAction,
 } from "@/app/actions/account";
@@ -16,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ALLOWED_AVATAR_CONTENT_TYPES, MAX_AVATAR_BYTES } from "@/lib/storage";
 
 function FieldError({ messages }: { messages?: string[] }) {
   if (!messages?.length) return null;
@@ -33,6 +37,7 @@ function AccountSettingsForms({
   user: NonNullable<Session["user"]>;
   updateSession: NonNullable<ReturnType<typeof useSession>["update"]>;
 }) {
+  const avatarInputRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState(user.name ?? "");
   const [newEmail, setNewEmail] = useState(user.email);
   const [emailCurrentPassword, setEmailCurrentPassword] = useState("");
@@ -58,6 +63,9 @@ function AccountSettingsForms({
 
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleteFieldErrors, setDeleteFieldErrors] = useState<Record<string, string[]>>({});
+  const [avatarError, setAvatarError] = useState<string | null>(null);
+  const [avatarMessage, setAvatarMessage] = useState<string | null>(null);
+  const [pendingAvatar, startAvatar] = useTransition();
 
   const [pendingProfile, startProfile] = useTransition();
   const [pendingEmail, startEmail] = useTransition();
@@ -66,8 +74,117 @@ function AccountSettingsForms({
 
   const emailVerified = user.emailVerified;
 
+  const avatarMaxMb = (MAX_AVATAR_BYTES / (1024 * 1024)).toFixed(0);
+  const allowedAvatarAccept = ALLOWED_AVATAR_CONTENT_TYPES.join(",");
+
   return (
     <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Avatar</CardTitle>
+          <CardDescription>
+            Upload a JPG, PNG, WEBP, or GIF up to {avatarMaxMb} MB. The file uploads directly to
+            storage using a short-lived signed URL.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3">
+              <div className="bg-muted text-muted-foreground flex size-12 items-center justify-center overflow-hidden rounded-full text-xs">
+                {user.image ? (
+                  <Image
+                    src={user.image}
+                    alt="Current avatar"
+                    className="size-full object-cover"
+                    width={48}
+                    height={48}
+                    unoptimized
+                  />
+                ) : (
+                  "None"
+                )}
+              </div>
+              <p className="text-muted-foreground text-sm">
+                {user.image ? "Current avatar image." : "No avatar uploaded yet."}
+              </p>
+            </div>
+            <Input
+              ref={avatarInputRef}
+              id="account-avatar-file"
+              type="file"
+              accept={allowedAvatarAccept}
+              disabled={pendingAvatar}
+            />
+          </div>
+          {avatarError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Could not upload avatar</AlertTitle>
+              <AlertDescription>{avatarError}</AlertDescription>
+            </Alert>
+          ) : null}
+          {avatarMessage ? (
+            <Alert>
+              <AlertTitle>Avatar updated</AlertTitle>
+              <AlertDescription>{avatarMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+          <Button
+            type="button"
+            disabled={pendingAvatar}
+            onClick={() => {
+              setAvatarError(null);
+              setAvatarMessage(null);
+              const file = avatarInputRef.current?.files?.[0];
+              if (!file) {
+                setAvatarError("Choose an image file first.");
+                return;
+              }
+              startAvatar(async () => {
+                const presign = await presignAvatarUploadAction({
+                  contentType: file.type,
+                  contentLength: file.size,
+                });
+                if (!presign.ok) {
+                  setAvatarError(presign.error);
+                  return;
+                }
+
+                const putRes = await fetch(presign.data.uploadUrl, {
+                  method: "PUT",
+                  headers: { "Content-Type": file.type },
+                  body: file,
+                });
+                if (!putRes.ok) {
+                  setAvatarError("Upload failed. Try again with a different image.");
+                  return;
+                }
+
+                const finalize = await finalizeAvatarUploadAction({
+                  objectKey: presign.data.objectKey,
+                });
+                if (!finalize.ok) {
+                  setAvatarError(finalize.error);
+                  return;
+                }
+                await updateSession({
+                  name: finalize.data.sessionUpdate.name,
+                  email: finalize.data.sessionUpdate.email,
+                  emailVerified: finalize.data.sessionUpdate.emailVerified,
+                  image: finalize.data.sessionUpdate.image,
+                });
+                if (avatarInputRef.current) {
+                  avatarInputRef.current.value = "";
+                }
+                setAvatarMessage("Your avatar was uploaded.");
+              });
+            }}
+          >
+            {pendingAvatar ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+            Upload avatar
+          </Button>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Profile</CardTitle>

--- a/app/actions/account.ts
+++ b/app/actions/account.ts
@@ -3,6 +3,7 @@
 import { ZodError } from "zod";
 
 import {
+  AccountStorageUnavailableError,
   AccountEmailConfirmMismatchError,
   AccountEmailTakenError,
   AccountNoPasswordError,
@@ -11,9 +12,12 @@ import {
   UnauthorizedAccountError,
   changePasswordForCurrentUser,
   deleteAccountForCurrentUser,
+  finalizeAvatarUploadForCurrentUser,
+  presignAvatarUploadForCurrentUser,
   updateEmailForCurrentUser,
   updateProfileForCurrentUser,
 } from "@/lib/account/service";
+import { AvatarValidationError } from "@/lib/storage";
 
 type AccountActionError = {
   ok: false;
@@ -61,6 +65,9 @@ function toAccountActionError(error: unknown): AccountActionError {
       fieldErrors: { confirmEmail: [error.message] },
     };
   }
+  if (error instanceof AvatarValidationError || error instanceof AccountStorageUnavailableError) {
+    return { ok: false, error: error.message };
+  }
   console.error(error);
   return { ok: false, error: "Something went wrong. Try again." };
 }
@@ -104,6 +111,33 @@ export async function deleteAccountAction(
   try {
     await deleteAccountForCurrentUser(raw);
     return { ok: true, data: { deleted: true } };
+  } catch (error) {
+    return toAccountActionError(error);
+  }
+}
+
+export async function presignAvatarUploadAction(raw: unknown): Promise<
+  | AccountActionSuccess<{
+      uploadUrl: string;
+      objectKey: string;
+      expiresInSeconds: number;
+    }>
+  | AccountActionError
+> {
+  try {
+    const data = await presignAvatarUploadForCurrentUser(raw);
+    return { ok: true, data };
+  } catch (error) {
+    return toAccountActionError(error);
+  }
+}
+
+export async function finalizeAvatarUploadAction(raw: unknown): Promise<
+  AccountActionSuccess<{ sessionUpdate: AccountSessionPatch }> | AccountActionError
+> {
+  try {
+    const patch = await finalizeAvatarUploadForCurrentUser(raw);
+    return { ok: true, data: { sessionUpdate: patch } };
   } catch (error) {
     return toAccountActionError(error);
   }

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -5,6 +5,12 @@ import { AuthError } from "next-auth";
 import { z } from "zod";
 
 import { signIn, signOut } from "@/auth";
+import { getTrustedClientIp } from "@/lib/auth/client-ip";
+import {
+  checkRateLimit,
+  recordRateLimitAttempt,
+  type RateLimitOptions,
+} from "@/lib/auth/rate-limit";
 import { prisma } from "@/lib/db";
 
 const signupSchema = z.object({
@@ -18,6 +24,30 @@ const signupSchema = z.object({
     .regex(/[0-9]/, "Password must include a number.")
     .regex(/[^a-zA-Z0-9]/, "Password must include a symbol."),
 });
+
+const SIGNUP_RATE_LIMIT: RateLimitOptions = {
+  maxAttempts: 5,
+  windowMs: 60 * 60 * 1000,
+};
+
+const SIGNUP_IP_RATE_LIMIT: RateLimitOptions = {
+  maxAttempts: 20,
+  windowMs: 60 * 60 * 1000,
+};
+
+const SIGNUP_GENERIC_ERROR =
+  "Unable to create an account with these details. Try logging in or use a different email.";
+
+const SIGNUP_RATE_LIMIT_MESSAGE =
+  "Too many signup attempts. Please wait and try again later.";
+
+function signupEmailRateLimitKey(email: string): string {
+  return `signup:${email.toLowerCase()}`;
+}
+
+function signupIpRateLimitKey(ip: string): string {
+  return `signup-ip:${ip}`;
+}
 
 export type SignupActionState = {
   message: string | null;
@@ -48,13 +78,42 @@ export async function signupAction(
   }
 
   const email = parsed.data.email.toLowerCase();
+  const clientIp = await getTrustedClientIp();
+
+  const emailRateLimit = checkRateLimit(
+    signupEmailRateLimitKey(email),
+    SIGNUP_RATE_LIMIT,
+  );
+  if (!emailRateLimit.allowed) {
+    return {
+      message: SIGNUP_RATE_LIMIT_MESSAGE,
+      success: false,
+      fieldErrors: {},
+    };
+  }
+
+  if (clientIp) {
+    const ipRateLimit = checkRateLimit(signupIpRateLimitKey(clientIp), SIGNUP_IP_RATE_LIMIT);
+    if (!ipRateLimit.allowed) {
+      return {
+        message: SIGNUP_RATE_LIMIT_MESSAGE,
+        success: false,
+        fieldErrors: {},
+      };
+    }
+  }
+
+  recordRateLimitAttempt(signupEmailRateLimitKey(email), SIGNUP_RATE_LIMIT);
+  if (clientIp) {
+    recordRateLimitAttempt(signupIpRateLimitKey(clientIp), SIGNUP_IP_RATE_LIMIT);
+  }
 
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) {
     return {
-      message: "This email is already in use.",
+      message: SIGNUP_GENERIC_ERROR,
       success: false,
-      fieldErrors: { email: ["This email is already in use."] },
+      fieldErrors: {},
     };
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,11 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-auth-brand: var(--auth-brand);
+  --color-auth-brand-end: var(--auth-brand-end);
+  --color-auth-form-bg: var(--auth-form-bg);
+  --color-auth-form-fg: var(--auth-form-fg);
+  --color-auth-form-muted: var(--auth-form-muted);
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
@@ -83,6 +88,11 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --auth-brand: oklch(0.35 0.18 255);
+  --auth-brand-end: oklch(0.28 0.15 260);
+  --auth-form-bg: oklch(1 0 0);
+  --auth-form-fg: oklch(0.145 0 0);
+  --auth-form-muted: oklch(0.556 0 0);
 }
 
 .dark {
@@ -125,5 +135,11 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  .auth-brand-gradient {
+    background: linear-gradient(135deg, var(--auth-brand), var(--auth-brand-end));
   }
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,17 +1,38 @@
 "use client";
 
-import Link from "next/link";
-import { Suspense, useState, useTransition } from "react";
+import { Suspense, useSyncExternalStore, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
 import { signIn } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 
+import { AuthBrandPanel } from "@/components/auth/auth-brand-panel";
+import { AuthField } from "@/components/auth/auth-field";
+import { AuthFormPanel } from "@/components/auth/auth-form-panel";
+import { AuthInput } from "@/components/auth/auth-input";
+import { AuthSplitLayout } from "@/components/auth/auth-split-layout";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { safePostLoginPath } from "@/lib/auth/safe-callback-url";
+import { safePostLoginPath, buildAuthHref } from "@/lib/auth/safe-callback-url";
+
+const BRAND_HEADLINE = "Fair shifts for every squad 📅";
+const BRAND_TAGLINE =
+  "Plan rotations, respect time off, and export your calendar—without the spreadsheet.";
+
+function useAuthHrefFromLocation(path: string): string {
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      window.addEventListener("popstate", onStoreChange);
+      return () => window.removeEventListener("popstate", onStoreChange);
+    },
+    () =>
+      buildAuthHref(
+        path,
+        new URLSearchParams(window.location.search).get("callbackUrl"),
+        window.location.origin,
+      ),
+    () => path,
+  );
+}
 
 function LoginForm() {
   const searchParams = useSearchParams();
@@ -19,53 +40,38 @@ function LoginForm() {
   const [error, setError] = useState<string | null>(null);
 
   return (
-    <>
-      <Card>
-        <CardHeader>
-          <CardTitle>Welcome back</CardTitle>
-          <CardDescription>Use your email and password.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form
-            className="space-y-4"
-            onSubmit={(event) => {
-              event.preventDefault();
-              setError(null);
-              const form = event.currentTarget;
-              const formData = new FormData(form);
-              startTransition(async () => {
-                const result = await signIn("credentials", {
-                  email: String(formData.get("email") ?? ""),
-                  password: String(formData.get("password") ?? ""),
-                  redirect: false,
-                });
-                if (result?.error) {
-                  setError("Invalid email or password.");
-                  return;
-                }
-                const next = safePostLoginPath(
-                  searchParams.get("callbackUrl"),
-                  window.location.origin,
-                );
-                window.location.assign(next);
-              });
-            }}
-          >
-            <div className="space-y-1">
-              <Label htmlFor="email">Email</Label>
-              <Input id="email" name="email" type="email" required />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="password">Password</Label>
-              <Input id="password" name="password" type="password" required />
-            </div>
-            <Button type="submit" className="w-full" disabled={isPending}>
-              {isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
-              Log in
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+    <form
+      className="space-y-6"
+      onSubmit={(event) => {
+        event.preventDefault();
+        setError(null);
+        const form = event.currentTarget;
+        const formData = new FormData(form);
+        startTransition(async () => {
+          const result = await signIn("credentials", {
+            email: String(formData.get("email") ?? ""),
+            password: String(formData.get("password") ?? ""),
+            redirect: false,
+          });
+          if (result?.error) {
+            setError("Invalid email or password.");
+            return;
+          }
+          const next = safePostLoginPath(
+            searchParams.get("callbackUrl"),
+            window.location.origin,
+          );
+          window.location.assign(next);
+        });
+      }}
+    >
+      <AuthField id="email" label="Email">
+        <AuthInput id="email" name="email" type="email" required />
+      </AuthField>
+
+      <AuthField id="password" label="Password">
+        <AuthInput id="password" name="password" type="password" required />
+      </AuthField>
 
       {error ? (
         <Alert variant="destructive">
@@ -73,46 +79,76 @@ function LoginForm() {
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       ) : null}
-    </>
+
+      <Button
+        type="submit"
+        className="h-11 w-full rounded-full bg-black text-white hover:bg-neutral-800"
+        disabled={isPending}
+      >
+        {isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+        Login Now
+      </Button>
+    </form>
+  );
+}
+
+function LoginContent() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl");
+  const registerHref = buildAuthHref("/register", callbackUrl, "http://local.invalid");
+
+  return (
+    <AuthSplitLayout
+      brand={<AuthBrandPanel headline={BRAND_HEADLINE} tagline={BRAND_TAGLINE} />}
+    >
+      <AuthFormPanel
+        brandName="Scalify"
+        brandHref="/"
+        title="Welcome Back!"
+        alternatePrompt="Don't have an account?"
+        alternateLinkLabel="Sign up"
+        alternateLinkHref={registerHref}
+        footerLinkLabel="Back to scheduler"
+        footerLinkHref="/"
+      >
+        <LoginForm />
+      </AuthFormPanel>
+    </AuthSplitLayout>
+  );
+}
+
+function LoginFallback() {
+  const registerHref = useAuthHrefFromLocation("/register");
+
+  return (
+    <AuthSplitLayout
+      brand={<AuthBrandPanel headline={BRAND_HEADLINE} tagline={BRAND_TAGLINE} />}
+    >
+      <AuthFormPanel
+        brandName="Scalify"
+        brandHref="/"
+        title="Welcome Back!"
+        alternatePrompt="Don't have an account?"
+        alternateLinkLabel="Sign up"
+        alternateLinkHref={registerHref}
+        footerLinkLabel="Back to scheduler"
+        footerLinkHref="/"
+      >
+        <div className="space-y-4" role="status" aria-live="polite">
+          <p className="text-sm text-auth-form-muted">Loading…</p>
+          <div className="h-10 animate-pulse rounded-sm bg-auth-form-muted/20" />
+          <div className="h-10 animate-pulse rounded-sm bg-auth-form-muted/20" />
+          <div className="h-11 animate-pulse rounded-full bg-auth-form-muted/30" />
+        </div>
+      </AuthFormPanel>
+    </AuthSplitLayout>
   );
 }
 
 export default function LoginPage() {
   return (
-    <main className="bg-background min-h-full px-4 py-10">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-6">
-        <div>
-          <h1 className="font-heading text-2xl font-semibold tracking-tight">Log in</h1>
-          <p className="text-muted-foreground text-sm">
-            Access your account. Scheduling remains available on the home page.
-          </p>
-        </div>
-
-        <Suspense
-          fallback={
-            <Card>
-              <CardHeader>
-                <CardTitle>Welcome back</CardTitle>
-                <CardDescription>Loading…</CardDescription>
-              </CardHeader>
-            </Card>
-          }
-        >
-          <LoginForm />
-        </Suspense>
-
-        <p className="text-muted-foreground text-sm">
-          Need an account?{" "}
-          <Link href="/register" className="text-primary underline-offset-4 hover:underline">
-            Create one
-          </Link>
-          .{" "}
-          <Link href="/" className="text-primary underline-offset-4 hover:underline">
-            Back to scheduler
-          </Link>
-          .
-        </p>
-      </div>
-    </main>
+    <Suspense fallback={<LoginFallback />}>
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useActionState, useEffect } from "react";
+import { Suspense, useActionState, useEffect } from "react";
 import { Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 
 import { type SignupActionState, signupAction } from "@/app/actions/auth";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -11,9 +11,13 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { buildAuthHref, safePostLoginPath } from "@/lib/auth/safe-callback-url";
 
-export default function RegisterPage() {
-  const router = useRouter();
+function RegisterContent() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl");
+  const loginHref = buildAuthHref("/login", callbackUrl, "http://local.invalid");
+
   const initialSignupState: SignupActionState = {
     message: null,
     success: false,
@@ -26,9 +30,9 @@ export default function RegisterPage() {
     if (!safeSignupState.success) {
       return;
     }
-    router.push("/");
-    router.refresh();
-  }, [router, safeSignupState.success]);
+    const next = safePostLoginPath(callbackUrl, window.location.origin);
+    window.location.assign(next);
+  }, [callbackUrl, safeSignupState.success]);
 
   return (
     <main className="bg-background min-h-full px-4 py-10">
@@ -91,7 +95,7 @@ export default function RegisterPage() {
 
         <p className="text-muted-foreground text-sm">
           Already registered?{" "}
-          <Link href="/login" className="text-primary underline-offset-4 hover:underline">
+          <Link href={loginHref} className="text-primary underline-offset-4 hover:underline">
             Log in
           </Link>
           .{" "}
@@ -102,5 +106,25 @@ export default function RegisterPage() {
         </p>
       </div>
     </main>
+  );
+}
+
+function RegisterFallback() {
+  return (
+    <main className="bg-background min-h-full px-4 py-10">
+      <div className="mx-auto flex w-full max-w-md flex-col gap-6">
+        <div role="status" aria-live="polite" className="text-sm text-muted-foreground">
+          Loading…
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense fallback={<RegisterFallback />}>
+      <RegisterContent />
+    </Suspense>
   );
 }

--- a/auth.ts
+++ b/auth.ts
@@ -7,11 +7,25 @@ import Credentials from "next-auth/providers/credentials";
 import { z } from "zod";
 
 import { prisma } from "@/lib/db";
+import {
+  checkRateLimit,
+  recordRateLimitAttempt,
+  type RateLimitOptions,
+} from "@/lib/auth/rate-limit";
 
 const authCredentialsSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
 });
+
+const LOGIN_RATE_LIMIT: RateLimitOptions = {
+  maxAttempts: 10,
+  windowMs: 15 * 60 * 1000,
+};
+
+function loginRateLimitKey(email: string): string {
+  return `login:${email.toLowerCase()}`;
+}
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
@@ -27,11 +41,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           return null;
         }
 
+        const email = parsed.data.email.toLowerCase();
+        const rateLimit = checkRateLimit(loginRateLimitKey(email), LOGIN_RATE_LIMIT);
+        if (!rateLimit.allowed) {
+          return null;
+        }
+
         const user = await prisma.user.findUnique({
-          where: { email: parsed.data.email.toLowerCase() },
+          where: { email },
         });
 
         if (!user?.passwordHash) {
+          recordRateLimitAttempt(loginRateLimitKey(email), LOGIN_RATE_LIMIT);
           return null;
         }
 
@@ -41,6 +62,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         );
 
         if (!validPassword) {
+          recordRateLimitAttempt(loginRateLimitKey(email), LOGIN_RATE_LIMIT);
           return null;
         }
 
@@ -52,7 +74,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     strategy: "jwt",
   },
   callbacks: {
-    jwt: async ({ token, user, trigger, session }) => {
+    jwt: async ({ token, user, trigger }) => {
       if (user) {
         const u = user as NextAuthUser;
         token.id = u.id;
@@ -63,25 +85,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           ? u.emailVerified.toISOString()
           : null;
       }
-      if (trigger === "update" && session) {
-        const s = session as {
-          name?: string | null;
-          email?: string;
-          emailVerified?: Date | string | null;
-          image?: string | null;
-        };
-        if (s.name !== undefined) token.name = s.name;
-        if (s.email !== undefined) token.email = s.email;
-        if (s.image !== undefined) token.picture = s.image;
-        if ("emailVerified" in s) {
-          if (s.emailVerified === null) {
-            token.emailVerified = null;
-          } else if (s.emailVerified instanceof Date) {
-            token.emailVerified = s.emailVerified.toISOString();
-          } else if (typeof s.emailVerified === "string") {
-            token.emailVerified = s.emailVerified;
-          }
+      if (trigger === "update" && token.id) {
+        const dbUser = await prisma.user.findUnique({
+          where: { id: String(token.id) },
+        });
+        if (!dbUser) {
+          return token;
         }
+        token.name = dbUser.name;
+        token.email = dbUser.email ?? undefined;
+        token.picture = dbUser.image;
+        token.emailVerified = dbUser.emailVerified
+          ? dbUser.emailVerified.toISOString()
+          : null;
       }
       return token;
     },

--- a/components/auth/auth-brand-panel.tsx
+++ b/components/auth/auth-brand-panel.tsx
@@ -1,0 +1,69 @@
+import { CalendarDays } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type AuthBrandPanelProps = {
+  headline: string;
+  tagline: string;
+  year?: number;
+  className?: string;
+};
+
+export function AuthBrandPanel({
+  headline,
+  tagline,
+  year = new Date().getFullYear(),
+  className,
+}: AuthBrandPanelProps) {
+  return (
+    <aside
+      className={cn(
+        "relative min-h-[40vh] overflow-hidden bg-gradient-to-br from-auth-brand to-auth-brand-end p-8 text-white md:min-h-screen md:p-12",
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 opacity-12" aria-hidden>
+        <svg
+          viewBox="0 0 1000 1000"
+          className="h-full w-full"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M-100 190C100 80 300 80 500 190C700 300 900 300 1100 190"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+          <path
+            d="M-100 460C100 350 300 350 500 460C700 570 900 570 1100 460"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+          <path
+            d="M-100 730C100 620 300 620 500 730C700 840 900 840 1100 730"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+        </svg>
+      </div>
+
+      <div className="relative z-10 flex h-full flex-col justify-between">
+        <div className="max-w-xl space-y-6">
+          <div className="inline-flex size-20 items-center justify-center rounded-full bg-white/10 p-5">
+            <CalendarDays className="size-10 text-white" aria-hidden />
+          </div>
+          <div className="space-y-4">
+            <h1 className="font-heading text-3xl font-bold tracking-tight md:text-4xl">
+              {headline}
+            </h1>
+            <p className="max-w-md text-base leading-relaxed text-white/90 md:text-lg">
+              {tagline}
+            </p>
+          </div>
+        </div>
+
+        <p className="pt-8 text-sm text-white/80">&copy; {year} Scalify</p>
+      </div>
+    </aside>
+  );
+}

--- a/components/auth/auth-field.tsx
+++ b/components/auth/auth-field.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+import { Label } from "@/components/ui/label";
+
+type AuthFieldProps = {
+  id: string;
+  label: string;
+  error?: string;
+  children: ReactNode;
+};
+
+export function AuthField({ id, label, error, children }: AuthFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id} className="text-sm text-auth-form-fg">
+        {label}
+      </Label>
+      {children}
+      {error ? (
+        <p id={`${id}-error`} className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/auth/auth-form-panel.tsx
+++ b/components/auth/auth-form-panel.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+type AuthFormPanelProps = {
+  brandName?: string;
+  brandHref?: string;
+  title: string;
+  alternatePrompt?: string;
+  alternateLinkLabel?: string;
+  alternateLinkHref?: string;
+  footerLinkLabel?: string;
+  footerLinkHref?: string;
+  children: ReactNode;
+  className?: string;
+};
+
+export function AuthFormPanel({
+  brandName = "Scalify",
+  brandHref = "/",
+  title,
+  alternatePrompt,
+  alternateLinkLabel,
+  alternateLinkHref,
+  footerLinkLabel,
+  footerLinkHref,
+  children,
+  className,
+}: AuthFormPanelProps) {
+  return (
+    <div className={cn("flex min-h-full flex-1 flex-col p-8 md:p-12", className)}>
+      <Link href={brandHref} className="font-heading text-lg font-semibold tracking-tight">
+        {brandName}
+      </Link>
+
+      <main className="flex flex-1 items-center justify-center py-10 md:py-12">
+        <div className="w-full max-w-md space-y-8">
+          <div className="space-y-2">
+            <h1 className="font-heading text-3xl font-bold tracking-tight">{title}</h1>
+            {alternatePrompt && alternateLinkLabel && alternateLinkHref ? (
+              <p className="text-sm text-auth-form-muted">
+                {alternatePrompt}{" "}
+                <Link
+                  href={alternateLinkHref}
+                  className="underline underline-offset-4 transition-opacity hover:opacity-80"
+                >
+                  {alternateLinkLabel}
+                </Link>
+              </p>
+            ) : null}
+          </div>
+
+          {children}
+        </div>
+      </main>
+
+      {footerLinkLabel && footerLinkHref ? (
+        <Link
+          href={footerLinkHref}
+          className="self-start text-sm text-auth-form-muted underline underline-offset-4 transition-opacity hover:opacity-80"
+        >
+          {footerLinkLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/components/auth/auth-input.tsx
+++ b/components/auth/auth-input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+const AuthInput = React.forwardRef<
+  HTMLInputElement,
+  React.ComponentProps<typeof Input>
+>(({ className, ...props }, ref) => (
+  <Input
+    ref={ref}
+    className={cn(
+      "h-10 rounded-none border-0 border-b border-auth-form-muted/50 bg-transparent px-0 text-auth-form-fg shadow-none placeholder:text-auth-form-muted focus-visible:border-auth-form-fg focus-visible:ring-0 aria-invalid:border-destructive aria-invalid:focus-visible:border-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+AuthInput.displayName = "AuthInput";
+
+export { AuthInput };

--- a/components/auth/auth-split-layout.tsx
+++ b/components/auth/auth-split-layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type AuthSplitLayoutProps = {
+  brand?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+export function AuthSplitLayout({ brand, children, className }: AuthSplitLayoutProps) {
+  return (
+    <main className={cn("min-h-screen w-full flex flex-col md:grid md:grid-cols-2", className)}>
+      <section className="min-h-[40vh] md:min-h-screen">{brand}</section>
+      <section className="bg-auth-form-bg text-auth-form-fg flex min-h-0 flex-col md:min-h-screen">
+        {children}
+      </section>
+    </main>
+  );
+}

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -89,6 +89,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [mobileNavOpen]);
 
+  const pathname = usePathname();
+
+  if (pathname === "/login" || pathname === "/register") {
+    return <div className="light min-h-screen">{children}</div>;
+  }
+
   const authed = status === "authenticated" && Boolean(session?.user);
 
   return (

--- a/components/schedule/schedule-calendar.tsx
+++ b/components/schedule/schedule-calendar.tsx
@@ -6,7 +6,7 @@ import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { addDays, formatISODateOnly, parseISODateOnly } from "@/lib/schedule/dates";
-import { getMemberColors, type MemberColorMode } from "@/lib/schedule/colors";
+import { buildMemberColorMap, type MemberColorMode } from "@/lib/schedule/colors";
 import type { DayAssignment } from "@/lib/schedule/types";
 import { cn } from "@/lib/utils";
 
@@ -58,6 +58,10 @@ export function ScheduleCalendar({
     for (const a of assignments) m.set(a.date, a);
     return m;
   }, [assignments]);
+  const colorMap = useMemo(
+    () => buildMemberColorMap(memberDisplayOrder, colorMode),
+    [memberDisplayOrder, colorMode],
+  );
 
   const weeks = useMemo(() => monthMatrix(cursor), [cursor]);
 
@@ -128,9 +132,7 @@ export function ScheduleCalendar({
               const sameMonth = day.getMonth() === cursor.getMonth();
               const assignment = byDate.get(iso);
               const assigneeId = assignment?.assigneeId ?? null;
-              const colors = assigneeId
-                ? getMemberColors(assigneeId, colorMode)
-                : null;
+              const colors = assigneeId ? colorMap.get(assigneeId) : null;
               const label = assigneeId
                 ? memberNames.get(assigneeId) ?? assigneeId
                 : inRange
@@ -162,9 +164,16 @@ export function ScheduleCalendar({
                     {day.getDate()}
                   </span>
                   {inRange ? (
-                    <span className="line-clamp-2 break-words text-[0.7rem] leading-tight">
-                      {assigneeId ? label : "Unassigned"}
-                    </span>
+                    <>
+                      <span className="line-clamp-2 break-words text-[0.7rem] leading-tight">
+                        {assigneeId ? label : "Unassigned"}
+                      </span>
+                      {assignment?.isPublicHoliday ? (
+                        <span className="mt-1 inline-flex w-fit rounded-full border border-black/70 bg-black px-1.5 py-0.5 text-[0.65rem] font-medium text-white">
+                          Holiday
+                        </span>
+                      ) : null}
+                    </>
                   ) : null}
                 </div>
               );
@@ -174,15 +183,19 @@ export function ScheduleCalendar({
             <span className="font-medium">People</span>
             {memberDisplayOrder.map((id) => {
               const name = memberNames.get(id)?.trim() || id;
-              const colors = getMemberColors(id, colorMode);
+              const colors = colorMap.get(id);
               return (
                 <span
                   key={id}
                   className="rounded-md border px-2 py-0.5 font-medium shadow-sm"
-                  style={{
-                    backgroundColor: colors.background,
-                    color: colors.foreground,
-                  }}
+                  style={
+                    colors
+                      ? {
+                          backgroundColor: colors.background,
+                          color: colors.foreground,
+                        }
+                      : undefined
+                  }
                 >
                   {name}
                 </span>

--- a/lib/account/service.ts
+++ b/lib/account/service.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
+import {
+  avatarObjectKeyBelongsToUser,
+  createS3ObjectStorageFromProcess,
+  isWellFormedAvatarObjectKey,
+  objectKeyFromPublicUrl,
+} from "@/lib/storage";
 
 const nameSchema = z
   .string()
@@ -35,6 +41,22 @@ const changePasswordSchema = z.object({
 const deleteAccountSchema = z.object({
   currentPassword: z.string().min(1, "Current password is required."),
   confirmEmail: z.string().trim().min(1, "Type your account email to confirm."),
+});
+
+const presignAvatarSchema = z.object({
+  contentType: z.string().trim().min(1, "Avatar content type is required."),
+  contentLength: z
+    .number()
+    .finite("Avatar size must be a number.")
+    .positive("Avatar size must be positive."),
+});
+
+const finalizeAvatarSchema = z.object({
+  objectKey: z
+    .string()
+    .trim()
+    .min(1, "Avatar object key is required.")
+    .refine((v) => isWellFormedAvatarObjectKey(v), "Avatar object key is invalid."),
 });
 
 export class UnauthorizedAccountError extends Error {
@@ -72,6 +94,13 @@ export class AccountEmailConfirmMismatchError extends Error {
   }
 }
 
+export class AccountStorageUnavailableError extends Error {
+  constructor() {
+    super("Avatar uploads are not configured right now.");
+    this.name = "AccountStorageUnavailableError";
+  }
+}
+
 async function requireUserId(): Promise<string> {
   const session = await auth();
   const id = session?.user?.id;
@@ -102,6 +131,41 @@ export type AccountSessionPatch = {
   image: string | null;
 };
 
+function toAccountSessionPatch(input: {
+  name: string | null;
+  email: string;
+  emailVerified: Date | null;
+  image: string | null;
+}): AccountSessionPatch {
+  return {
+    name: input.name,
+    email: input.email,
+    emailVerified: input.emailVerified,
+    image: input.image,
+  };
+}
+
+function tryCreateStorage() {
+  try {
+    return createS3ObjectStorageFromProcess();
+  } catch {
+    return null;
+  }
+}
+
+async function bestEffortDeleteAvatarByPublicUrl(imageUrl: string | null): Promise<void> {
+  if (!imageUrl) return;
+  const storage = tryCreateStorage();
+  if (!storage) return;
+  const objectKey = objectKeyFromPublicUrl(process.env.S3_PUBLIC_URL_BASE ?? "", imageUrl);
+  if (!objectKey || !isWellFormedAvatarObjectKey(objectKey)) return;
+  try {
+    await storage.deleteObject(objectKey);
+  } catch {
+    // Best-effort cleanup should not block account flows.
+  }
+}
+
 export async function updateProfileForCurrentUser(
   raw: unknown,
 ): Promise<AccountSessionPatch> {
@@ -118,10 +182,7 @@ export async function updateProfileForCurrentUser(
   });
 
   return {
-    name: updated.name,
-    email: updated.email,
-    emailVerified: updated.emailVerified,
-    image: updated.image,
+    ...toAccountSessionPatch(updated),
   };
 }
 
@@ -148,10 +209,7 @@ export async function updateEmailForCurrentUser(
 
   if (current.email.toLowerCase() === normalized) {
     return {
-      name: current.name,
-      email: current.email,
-      emailVerified: current.emailVerified,
-      image: current.image,
+      ...toAccountSessionPatch(current),
     };
   }
 
@@ -173,11 +231,66 @@ export async function updateEmailForCurrentUser(
   });
 
   return {
-    name: updated.name,
-    email: updated.email,
-    emailVerified: updated.emailVerified,
-    image: updated.image,
+    ...toAccountSessionPatch(updated),
   };
+}
+
+export async function presignAvatarUploadForCurrentUser(raw: unknown): Promise<{
+  uploadUrl: string;
+  objectKey: string;
+  expiresInSeconds: number;
+}> {
+  const userId = await requireUserId();
+  const parsed = presignAvatarSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+  const storage = tryCreateStorage();
+  if (!storage) {
+    throw new AccountStorageUnavailableError();
+  }
+  return storage.presignPutAvatar({
+    userId,
+    contentType: parsed.data.contentType,
+    contentLength: parsed.data.contentLength,
+  });
+}
+
+export async function finalizeAvatarUploadForCurrentUser(
+  raw: unknown,
+): Promise<AccountSessionPatch> {
+  const userId = await requireUserId();
+  const parsed = finalizeAvatarSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+  if (!avatarObjectKeyBelongsToUser(parsed.data.objectKey, userId)) {
+    throw new UnauthorizedAccountError();
+  }
+  const storage = tryCreateStorage();
+  if (!storage) {
+    throw new AccountStorageUnavailableError();
+  }
+  const newImageUrl = storage.getPublicUrlForKey(parsed.data.objectKey);
+  const current = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true, email: true, emailVerified: true, image: true },
+  });
+  if (!current) {
+    throw new UnauthorizedAccountError();
+  }
+
+  const updated = await prisma.user.update({
+    where: { id: userId },
+    data: { image: newImageUrl },
+    select: { name: true, email: true, emailVerified: true, image: true },
+  });
+
+  if (current.image && current.image !== newImageUrl) {
+    await bestEffortDeleteAvatarByPublicUrl(current.image);
+  }
+
+  return toAccountSessionPatch(updated);
 }
 
 export async function changePasswordForCurrentUser(raw: unknown): Promise<void> {
@@ -205,7 +318,7 @@ export async function deleteAccountForCurrentUser(raw: unknown): Promise<void> {
 
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { email: true },
+    select: { email: true, image: true },
   });
   if (!user) {
     throw new UnauthorizedAccountError();
@@ -218,5 +331,6 @@ export async function deleteAccountForCurrentUser(raw: unknown): Promise<void> {
     throw new AccountEmailConfirmMismatchError();
   }
 
+  await bestEffortDeleteAvatarByPublicUrl(user.image);
   await prisma.user.delete({ where: { id: userId } });
 }

--- a/lib/auth/client-ip.ts
+++ b/lib/auth/client-ip.ts
@@ -1,0 +1,23 @@
+import { headers } from "next/headers";
+
+/**
+ * Returns a client IP only when TRUST_PROXY is enabled, indicating the app
+ * runs behind a trusted reverse proxy that sets x-forwarded-for / x-real-ip.
+ * Without that, those headers are spoofable and must not drive rate limits.
+ */
+export async function getTrustedClientIp(): Promise<string | null> {
+  if (process.env.TRUST_PROXY !== "true") {
+    return null;
+  }
+
+  const headerList = await headers();
+  const forwarded = headerList.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) {
+      return first;
+    }
+  }
+
+  return headerList.get("x-real-ip")?.trim() ?? null;
+}

--- a/lib/auth/protected-routes.ts
+++ b/lib/auth/protected-routes.ts
@@ -1,0 +1,31 @@
+const SIGN_IN_PATH = "/login";
+
+export function isProtectedPath(pathname: string): boolean {
+  return (
+    pathname === "/teams" ||
+    pathname.startsWith("/teams/") ||
+    pathname === "/account" ||
+    pathname.startsWith("/account/")
+  );
+}
+
+export function buildLoginRedirectUrl(
+  requestPathname: string,
+  requestSearch: string,
+  origin: string,
+): URL {
+  const url = new URL(SIGN_IN_PATH, origin);
+  const returnPath = `${requestPathname}${requestSearch}`;
+  url.searchParams.set("callbackUrl", returnPath);
+  return url;
+}
+
+/**
+ * Fail-closed: unauthenticated users (no token) must be redirected to login,
+ * including when AUTH_SECRET is missing and JWT verification cannot succeed.
+ */
+export function shouldRedirectUnauthenticatedToLogin(token: unknown): boolean {
+  return !token;
+}
+
+export { SIGN_IN_PATH };

--- a/lib/auth/rate-limit.ts
+++ b/lib/auth/rate-limit.ts
@@ -1,0 +1,71 @@
+type RateLimitEntry = {
+  timestamps: number[];
+};
+
+const store = new Map<string, RateLimitEntry>();
+
+export type RateLimitOptions = {
+  maxAttempts: number;
+  windowMs: number;
+};
+
+export type RateLimitResult = {
+  allowed: boolean;
+  retryAfterMs?: number;
+};
+
+function pruneExpiredTimestamps(entry: RateLimitEntry, windowStart: number): void {
+  entry.timestamps = entry.timestamps.filter((timestamp) => timestamp > windowStart);
+}
+
+function cleanupStore(windowMs: number): void {
+  const windowStart = Date.now() - windowMs;
+  for (const [key, entry] of store) {
+    pruneExpiredTimestamps(entry, windowStart);
+    if (entry.timestamps.length === 0) {
+      store.delete(key);
+    }
+  }
+}
+
+export function checkRateLimit(key: string, options: RateLimitOptions): RateLimitResult {
+  cleanupStore(options.windowMs);
+
+  const now = Date.now();
+  const windowStart = now - options.windowMs;
+  let entry = store.get(key);
+  if (!entry) {
+    entry = { timestamps: [] };
+    store.set(key, entry);
+  }
+
+  pruneExpiredTimestamps(entry, windowStart);
+
+  if (entry.timestamps.length >= options.maxAttempts) {
+    const oldestInWindow = entry.timestamps[0] ?? now;
+    return {
+      allowed: false,
+      retryAfterMs: Math.max(0, oldestInWindow + options.windowMs - now),
+    };
+  }
+
+  return { allowed: true };
+}
+
+export function recordRateLimitAttempt(key: string, options: RateLimitOptions): void {
+  const now = Date.now();
+  const windowStart = now - options.windowMs;
+  let entry = store.get(key);
+  if (!entry) {
+    entry = { timestamps: [] };
+    store.set(key, entry);
+  }
+
+  pruneExpiredTimestamps(entry, windowStart);
+  entry.timestamps.push(now);
+}
+
+/** Clears in-memory rate limit state (for tests). */
+export function resetRateLimitStore(): void {
+  store.clear();
+}

--- a/lib/auth/safe-callback-url.ts
+++ b/lib/auth/safe-callback-url.ts
@@ -1,4 +1,23 @@
 /**
+ * Builds an auth page href, preserving a safe callbackUrl query param when present.
+ */
+export function buildAuthHref(
+  path: string,
+  callbackUrl: string | null | undefined,
+  origin: string,
+): string {
+  if (!callbackUrl?.trim()) {
+    return path;
+  }
+  const safe = safePostLoginPath(callbackUrl, origin);
+  if (safe === "/") {
+    return path;
+  }
+  const params = new URLSearchParams({ callbackUrl: callbackUrl.trim() });
+  return `${path}?${params.toString()}`;
+}
+
+/**
  * Resolves a post-login redirect target from `callbackUrl` query param.
  * Only same-origin paths are allowed; auth pages fall back to `/`.
  */

--- a/lib/schedule/assign.ts
+++ b/lib/schedule/assign.ts
@@ -23,10 +23,13 @@ function enumerateDaysInclusive(start: Date, end: Date): Date[] {
 function poolForDay(
   date: Date,
   isPublicHoliday: HolidayChecker,
-): { pool: ShiftPool; hours: number } {
-  const weekendOrHoliday = isWeekend(date) || isPublicHoliday(date);
-  if (weekendOrHoliday) return { pool: "B", hours: 24 };
-  return { pool: "A", hours: 12 };
+): { pool: ShiftPool; hours: number; isPublicHoliday: boolean } {
+  const isHoliday = isPublicHoliday(date);
+  const weekendOrHoliday = isWeekend(date) || isHoliday;
+  if (weekendOrHoliday) {
+    return { pool: "B", hours: 24, isPublicHoliday: isHoliday };
+  }
+  return { pool: "A", hours: 12, isPublicHoliday: isHoliday };
 }
 
 /** `YYYY-MM` from ISO date string */
@@ -141,7 +144,10 @@ export function assignShifts(
   for (const day of days) {
     const dateStr = formatISODateOnly(day);
     const mk = monthKey(dateStr);
-    const { pool, hours } = poolForDay(day, isPublicHoliday);
+    const { pool, hours, isPublicHoliday: isDayPublicHoliday } = poolForDay(
+      day,
+      isPublicHoliday,
+    );
 
     const available = input.members.filter(
       (m) => !m.unavailableDates.includes(dateStr),
@@ -169,6 +175,7 @@ export function assignShifts(
         pool,
         assigneeId: null,
         hours,
+        isPublicHoliday: isDayPublicHoliday,
       });
       warnings.push({ date: dateStr, code: "no_available_member" });
       continue;
@@ -209,12 +216,14 @@ export function assignShifts(
       pool,
       assigneeId: chosenId,
       hours,
+      isPublicHoliday: isDayPublicHoliday,
     });
     assignmentsByDate.set(dateStr, {
       date: dateStr,
       pool,
       assigneeId: chosenId,
       hours,
+      isPublicHoliday: isDayPublicHoliday,
     });
   }
 

--- a/lib/schedule/colors.ts
+++ b/lib/schedule/colors.ts
@@ -5,18 +5,8 @@ export type MemberColors = {
 
 export type MemberColorMode = "normal" | "colorblind";
 
-function hashString(s: string): number {
-  let h = 0;
-  for (let i = 0; i < s.length; i++) {
-    h = (h << 5) - h + s.charCodeAt(i);
-    h |= 0;
-  }
-  return Math.abs(h);
-}
-
-// Fixed palettes of strongly separated colors. These are intentionally
-// discrete (no continuous hue wheel) so even when ids hash close together,
-// the assigned colors remain clearly distinct.
+// Fixed palettes of strongly separated colors so adjacent positions remain
+// visually distinct.
 const NORMAL_PALETTE: MemberColors[] = [
   { background: "oklch(0.93 0.14 25)", foreground: "oklch(0.3 0.12 25)" }, // orange
   { background: "oklch(0.93 0.14 60)", foreground: "oklch(0.3 0.11 60)" }, // yellow
@@ -52,23 +42,17 @@ const COLORBLIND_PALETTE: MemberColors[] = [
   { background: "oklch(0.9 0.16 10)", foreground: "oklch(0.3 0.13 10)" }, // red
 ];
 
-/**
- * Distinct, readable HSL backgrounds per member; foreground is dark or light text.
- */
-export function getMemberColors(
-  memberId: string,
+export function buildMemberColorMap(
+  memberIds: string[],
   mode: MemberColorMode = "normal",
-): MemberColors {
-  const h = hashString(memberId);
+): Map<string, MemberColors> {
+  const palette = mode === "colorblind" ? COLORBLIND_PALETTE : NORMAL_PALETTE;
+  const memberColorMap = new Map<string, MemberColors>();
 
-  if (mode === "colorblind") {
-    const idx = h % COLORBLIND_PALETTE.length;
-    return COLORBLIND_PALETTE[idx]!;
-  }
+  memberIds.forEach((memberId, index) => {
+    // Wrap around to the start when team size exceeds the palette length.
+    memberColorMap.set(memberId, palette[index % palette.length]!);
+  });
 
-  // Normal mode: choose from a fixed palette of high-contrast colors. This
-  // guarantees discrete, visually separated colors instead of relying on
-  // small hue differences.
-  const idx = h % NORMAL_PALETTE.length;
-  return NORMAL_PALETTE[idx]!;
+  return memberColorMap;
 }

--- a/lib/schedule/csv.ts
+++ b/lib/schedule/csv.ts
@@ -97,12 +97,13 @@ function buildCalendarSections(
 
         const a = assignmentByDate.get(iso);
         const dayNum = String(day.getDate());
+        const suffix = a?.isPublicHoliday ? " (Holiday)" : "";
         if (!a?.assigneeId) {
-          cells.push(`${dayNum} - Unassigned`);
+          cells.push(`${dayNum} - Unassigned${suffix}`);
         } else {
           const name =
             memberNames.get(a.assigneeId)?.trim() || a.assigneeId;
-          cells.push(`${dayNum} - ${name}`);
+          cells.push(`${dayNum} - ${name}${suffix}`);
         }
       }
       if (anyInMonth) {

--- a/lib/schedule/types.ts
+++ b/lib/schedule/types.ts
@@ -25,6 +25,7 @@ export type DayAssignment = {
   pool: ShiftPool;
   assigneeId: string | null;
   hours: number;
+  isPublicHoliday: boolean;
 };
 
 export type PersonReport = {

--- a/lib/storage/avatar-key.ts
+++ b/lib/storage/avatar-key.ts
@@ -30,3 +30,15 @@ export function isWellFormedAvatarObjectKey(key: string): boolean {
   if (segments.length < 2) return false;
   return segments.every((s) => s.length > 0 && !s.includes(".."));
 }
+
+/**
+ * Validates ownership for keys generated as `avatars/{userId}/{objectId}`.
+ * This is enforced during finalize/delete flows to prevent cross-user writes.
+ */
+export function avatarObjectKeyBelongsToUser(
+  key: string,
+  userId: string,
+): boolean {
+  assertSafeUserId(userId);
+  return isWellFormedAvatarObjectKey(key) && key.startsWith(`${AVATAR_OBJECT_PREFIX}${userId}/`);
+}

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -24,6 +24,7 @@ export {
   normalizeAvatarContentType,
 } from "@/lib/storage/avatar-validation";
 export {
+  avatarObjectKeyBelongsToUser,
   isWellFormedAvatarObjectKey,
   makeAvatarObjectKey,
 } from "@/lib/storage/avatar-key";

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,16 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
 
-const SIGN_IN_PATH = "/login";
-
-function isProtectedPath(pathname: string): boolean {
-  return (
-    pathname === "/teams" ||
-    pathname.startsWith("/teams/") ||
-    pathname === "/account" ||
-    pathname.startsWith("/account/")
-  );
-}
+import {
+  buildLoginRedirectUrl,
+  isProtectedPath,
+  shouldRedirectUnauthenticatedToLogin,
+} from "@/lib/auth/protected-routes";
 
 export async function middleware(request: NextRequest) {
   if (!isProtectedPath(request.nextUrl.pathname)) {
@@ -18,19 +13,26 @@ export async function middleware(request: NextRequest) {
   }
 
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
-  if (!secret) {
+  if (!secret && process.env.NODE_ENV === "production") {
+    console.error(
+      "AUTH_SECRET (or NEXTAUTH_SECRET) is not set; protected routes fail closed.",
+    );
+  } else if (!secret) {
+    console.warn(
+      "AUTH_SECRET (or NEXTAUTH_SECRET) is not set; protected routes fail closed.",
+    );
+  }
+
+  const token = secret ? await getToken({ req: request, secret }) : null;
+  if (!shouldRedirectUnauthenticatedToLogin(token)) {
     return NextResponse.next();
   }
 
-  const token = await getToken({ req: request, secret });
-  if (token) {
-    return NextResponse.next();
-  }
-
-  const url = request.nextUrl.clone();
-  url.pathname = SIGN_IN_PATH;
-  const returnPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
-  url.searchParams.set("callbackUrl", returnPath);
+  const url = buildLoginRedirectUrl(
+    request.nextUrl.pathname,
+    request.nextUrl.search,
+    request.nextUrl.origin,
+  );
   return NextResponse.redirect(url);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "date-fns": "^4.1.0",
         "date-holidays": "^3.27.0",
         "lucide-react": "^1.8.0",
-        "next": "16.2.3",
+        "next": "16.2.6",
         "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
         "pg": "^8.20.0",
@@ -39,7 +39,7 @@
         "@types/react-dom": "^19",
         "dotenv": "^17.4.2",
         "eslint": "^9",
-        "eslint-config-next": "16.2.3",
+        "eslint-config-next": "16.2.6",
         "prisma": "^7.8.0",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -1905,12 +1905,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.3.tgz",
+      "integrity": "sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2662,15 +2662,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
-      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.3.tgz",
-      "integrity": "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2678,9 +2678,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
-      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -2694,9 +2694,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -2710,9 +2710,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -2726,9 +2726,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -2742,9 +2742,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -2758,9 +2758,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -2774,9 +2774,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -3027,19 +3027,6 @@
         "std-env": "3.10.0",
         "valibot": "1.2.0",
         "zeptomatch": "2.1.0"
-      }
-    },
-    "node_modules/@prisma/dev/node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
       }
     },
     "node_modules/@prisma/driver-adapter-utils": {
@@ -4693,9 +4680,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5048,9 +5035,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7292,13 +7279,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.3.tgz",
-      "integrity": "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
+      "integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.3",
+        "@next/eslint-plugin-next": "16.2.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -7770,12 +7757,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7868,9 +7855,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7884,9 +7871,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -7895,7 +7882,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -8551,9 +8539,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -8681,9 +8669,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -10142,9 +10130,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -10192,12 +10180,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
-      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.3",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -10211,14 +10199,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.3",
-        "@next/swc-darwin-x64": "16.2.3",
-        "@next/swc-linux-arm64-gnu": "16.2.3",
-        "@next/swc-linux-arm64-musl": "16.2.3",
-        "@next/swc-linux-x64-gnu": "16.2.3",
-        "@next/swc-linux-x64-musl": "16.2.3",
-        "@next/swc-win32-arm64-msvc": "16.2.3",
-        "@next/swc-win32-x64-msvc": "16.2.3",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -10279,34 +10267,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-domexception": {
@@ -10988,9 +10948,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -11007,7 +10967,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13497,6 +13457,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "date-fns": "^4.1.0",
     "date-holidays": "^3.27.0",
     "lucide-react": "^1.8.0",
-    "next": "16.2.3",
+    "next": "16.2.6",
     "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",
     "pg": "^8.20.0",
@@ -44,10 +44,14 @@
     "@types/react-dom": "^19",
     "dotenv": "^17.4.2",
     "eslint": "^9",
-    "eslint-config-next": "16.2.3",
+    "eslint-config-next": "16.2.6",
     "prisma": "^7.8.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "@hono/node-server": ">=1.19.13",
+    "postcss": ">=8.5.10"
   }
 }

--- a/tests/assign-shifts-holidays.integration.test.ts
+++ b/tests/assign-shifts-holidays.integration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { assignShifts } from "@/lib/schedule/assign";
+import { createHolidayChecker } from "@/lib/schedule/holidays";
+import type { ScheduleInput } from "@/lib/schedule/types";
+
+describe("assignShifts holiday propagation", () => {
+  it("marks holiday dates with isPublicHoliday=true", () => {
+    const input: ScheduleInput = {
+      startDate: "2026-01-01",
+      endDate: "2026-01-02",
+      holidayCountry: "US",
+      members: [
+        { id: "m1", name: "Ana", unavailableDates: [] },
+        { id: "m2", name: "Bruno", unavailableDates: [] },
+      ],
+    };
+
+    const result = assignShifts(input, createHolidayChecker("US"));
+    const jan1 = result.assignments.find(
+      (assignment) => assignment.date === "2026-01-01",
+    );
+    const jan2 = result.assignments.find(
+      (assignment) => assignment.date === "2026-01-02",
+    );
+
+    expect(jan1).toBeDefined();
+    expect(jan1?.isPublicHoliday).toBe(true);
+    expect(jan2).toBeDefined();
+    expect(jan2?.isPublicHoliday).toBe(false);
+  });
+});

--- a/tests/member-colors.test.ts
+++ b/tests/member-colors.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMemberColorMap } from "@/lib/schedule/colors";
+
+function buildMemberIds(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `member-${index + 1}`);
+}
+
+function toColorKey(color: { background: string; foreground: string }): string {
+  return `${color.background}|${color.foreground}`;
+}
+
+describe("buildMemberColorMap", () => {
+  it("returns 16 distinct colors in normal mode when team size is within palette size", () => {
+    const memberIds = buildMemberIds(16);
+    const colorMap = buildMemberColorMap(memberIds, "normal");
+
+    const distinctColorKeys = new Set(
+      memberIds.map((memberId) => toColorKey(colorMap.get(memberId)!)),
+    );
+
+    expect(distinctColorKeys.size).toBe(16);
+  });
+
+  it("returns 12 distinct colors in colorblind mode when team size is within palette size", () => {
+    const memberIds = buildMemberIds(12);
+    const colorMap = buildMemberColorMap(memberIds, "colorblind");
+
+    const distinctColorKeys = new Set(
+      memberIds.map((memberId) => toColorKey(colorMap.get(memberId)!)),
+    );
+
+    expect(distinctColorKeys.size).toBe(12);
+  });
+
+  it("wraps around the normal palette when team size exceeds 16 members", () => {
+    const memberIds = buildMemberIds(19);
+    const colorMap = buildMemberColorMap(memberIds, "normal");
+
+    expect(toColorKey(colorMap.get("member-1")!)).toBe(
+      toColorKey(colorMap.get("member-17")!),
+    );
+    expect(toColorKey(colorMap.get("member-2")!)).toBe(
+      toColorKey(colorMap.get("member-18")!),
+    );
+    expect(toColorKey(colorMap.get("member-3")!)).toBe(
+      toColorKey(colorMap.get("member-19")!),
+    );
+  });
+
+  it("returns the same color assignment for the same member order", () => {
+    const memberIds = ["m-1", "m-2", "m-3", "m-4", "m-5"];
+
+    const firstMap = buildMemberColorMap(memberIds, "normal");
+    const secondMap = buildMemberColorMap(memberIds, "normal");
+
+    expect(memberIds.map((memberId) => firstMap.get(memberId))).toEqual(
+      memberIds.map((memberId) => secondMap.get(memberId)),
+    );
+  });
+
+  it("assigns colors by position instead of member id values", () => {
+    const firstOrder = ["alpha", "bravo", "charlie", "delta"];
+    const secondOrder = ["u-101", "u-202", "u-303", "u-404"];
+
+    const firstMap = buildMemberColorMap(firstOrder, "normal");
+    const secondMap = buildMemberColorMap(secondOrder, "normal");
+
+    expect(firstOrder.map((memberId) => firstMap.get(memberId))).toEqual(
+      secondOrder.map((memberId) => secondMap.get(memberId)),
+    );
+  });
+});

--- a/tests/protected-routes.test.ts
+++ b/tests/protected-routes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLoginRedirectUrl,
+  isProtectedPath,
+  shouldRedirectUnauthenticatedToLogin,
+} from "@/lib/auth/protected-routes";
+
+describe("isProtectedPath", () => {
+  it("matches account and teams routes", () => {
+    expect(isProtectedPath("/account")).toBe(true);
+    expect(isProtectedPath("/account/settings")).toBe(true);
+    expect(isProtectedPath("/teams")).toBe(true);
+    expect(isProtectedPath("/teams/abc")).toBe(true);
+  });
+
+  it("does not match public routes", () => {
+    expect(isProtectedPath("/")).toBe(false);
+    expect(isProtectedPath("/login")).toBe(false);
+    expect(isProtectedPath("/register")).toBe(false);
+  });
+});
+
+describe("shouldRedirectUnauthenticatedToLogin", () => {
+  it("redirects when token is missing (fail-closed without secret)", () => {
+    expect(shouldRedirectUnauthenticatedToLogin(null)).toBe(true);
+    expect(shouldRedirectUnauthenticatedToLogin(undefined)).toBe(true);
+  });
+
+  it("allows access when token is present", () => {
+    expect(shouldRedirectUnauthenticatedToLogin({ sub: "1" })).toBe(false);
+  });
+});
+
+describe("buildLoginRedirectUrl", () => {
+  it("preserves return path in callbackUrl", () => {
+    const url = buildLoginRedirectUrl("/account", "?tab=profile", "https://app.example");
+    expect(url.pathname).toBe("/login");
+    expect(url.searchParams.get("callbackUrl")).toBe("/account?tab=profile");
+    expect(url.origin).toBe("https://app.example");
+  });
+});

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  checkRateLimit,
+  recordRateLimitAttempt,
+  resetRateLimitStore,
+} from "@/lib/auth/rate-limit";
+
+describe("checkRateLimit", () => {
+  afterEach(() => {
+    resetRateLimitStore();
+    vi.useRealTimers();
+  });
+
+  it("allows attempts under the limit", () => {
+    const options = { maxAttempts: 3, windowMs: 60_000 };
+
+    expect(checkRateLimit("user:a", options)).toEqual({ allowed: true });
+    recordRateLimitAttempt("user:a", options);
+    expect(checkRateLimit("user:a", options)).toEqual({ allowed: true });
+    recordRateLimitAttempt("user:a", options);
+    expect(checkRateLimit("user:a", options)).toEqual({ allowed: true });
+  });
+
+  it("blocks when max attempts are reached within the window", () => {
+    const options = { maxAttempts: 2, windowMs: 60_000 };
+
+    recordRateLimitAttempt("user:b", options);
+    recordRateLimitAttempt("user:b", options);
+
+    const result = checkRateLimit("user:b", options);
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("expires attempts after the window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-20T12:00:00Z"));
+
+    const options = { maxAttempts: 1, windowMs: 1_000 };
+    recordRateLimitAttempt("user:c", options);
+    expect(checkRateLimit("user:c", options).allowed).toBe(false);
+
+    vi.setSystemTime(new Date("2026-06-20T12:00:02Z"));
+    expect(checkRateLimit("user:c", options)).toEqual({ allowed: true });
+  });
+
+  it("tracks keys independently", () => {
+    const options = { maxAttempts: 1, windowMs: 60_000 };
+
+    recordRateLimitAttempt("user:d", options);
+    expect(checkRateLimit("user:d", options).allowed).toBe(false);
+    expect(checkRateLimit("user:e", options)).toEqual({ allowed: true });
+  });
+});

--- a/tests/safe-callback-url.test.ts
+++ b/tests/safe-callback-url.test.ts
@@ -1,8 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { safePostLoginPath } from "@/lib/auth/safe-callback-url";
+import { buildAuthHref, safePostLoginPath } from "@/lib/auth/safe-callback-url";
 
 const origin = "http://localhost:3000";
+
+describe("buildAuthHref", () => {
+  it("returns path unchanged when callback is missing", () => {
+    expect(buildAuthHref("/register", null, origin)).toBe("/register");
+    expect(buildAuthHref("/login", undefined, origin)).toBe("/login");
+    expect(buildAuthHref("/login", "  ", origin)).toBe("/login");
+  });
+
+  it("appends safe callbackUrl query param", () => {
+    expect(buildAuthHref("/register", "/account", origin)).toBe(
+      "/register?callbackUrl=%2Faccount",
+    );
+    expect(buildAuthHref("/login", "/teams?tab=1", origin)).toBe(
+      "/login?callbackUrl=%2Fteams%3Ftab%3D1",
+    );
+  });
+
+  it("omits unsafe callbackUrl values", () => {
+    expect(buildAuthHref("/register", "https://evil.example", origin)).toBe("/register");
+    expect(buildAuthHref("/login", "/login", origin)).toBe("/login");
+  });
+});
 
 describe("safePostLoginPath", () => {
   it("defaults to home when callback is missing", () => {

--- a/tests/storage-avatar.test.ts
+++ b/tests/storage-avatar.test.ts
@@ -5,7 +5,11 @@ import {
   AvatarValidationError,
   normalizeAvatarContentType,
 } from "@/lib/storage/avatar-validation";
-import { isWellFormedAvatarObjectKey, makeAvatarObjectKey } from "@/lib/storage/avatar-key";
+import {
+  avatarObjectKeyBelongsToUser,
+  isWellFormedAvatarObjectKey,
+  makeAvatarObjectKey,
+} from "@/lib/storage/avatar-key";
 import { MAX_AVATAR_BYTES } from "@/lib/storage/constants";
 import {
   composePublicObjectUrl,
@@ -72,6 +76,19 @@ describe("isWellFormedAvatarObjectKey", () => {
     expect(isWellFormedAvatarObjectKey("other/avatars/x")).toBe(false);
     expect(isWellFormedAvatarObjectKey("avatars/../x")).toBe(false);
     expect(isWellFormedAvatarObjectKey("avatars/onlyone")).toBe(false);
+  });
+});
+
+describe("avatarObjectKeyBelongsToUser", () => {
+  it("accepts keys minted for the same user id", () => {
+    const userId = "clabcdefghijklmn";
+    const key = makeAvatarObjectKey(userId);
+    expect(avatarObjectKeyBelongsToUser(key, userId)).toBe(true);
+  });
+
+  it("rejects keys that target a different user", () => {
+    const key = "avatars/cluserone1234/fileid";
+    expect(avatarObjectKeyBelongsToUser(key, "clusertwo5678")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Redesigns /login with a split-screen layout (brand panel + form panel) and reusable auth components
- Preserves callbackUrl across login, register, and post-signup redirect paths
- Hardens auth: in-memory rate limiting, fail-closed middleware, JWT DB refresh on session update, generic signup errors, and TRUST_PROXY-gated IP throttling

**Note:** This branch is based on eat/sca0022-account-avatar-presign-finalize, so the PR also includes the SCA0022 avatar presign/finalize commit.

## Test plan
- [ ] Open /login and verify split layout on desktop and stacked layout on mobile
- [ ] Visit /account while signed out, follow Sign up, complete registration, confirm redirect to /account
- [ ] Verify invalid credentials show error alert; successful login respects callbackUrl
- [ ] Run 
pm run lint, 
pm test, and 
pm run build

Made with [Cursor](https://cursor.com)